### PR TITLE
Redirect Hotfix

### DIFF
--- a/_docs/deploy-to-kubernetes/getting-started-with-gke.md
+++ b/_docs/deploy-to-kubernetes/getting-started-with-gke.md
@@ -7,6 +7,7 @@ permalink: /:collection/deploy-to-kubernetes/get-ready-to-deploy/
 # /docs/CATEGORY_OF_FILE/NEW_PAGE_NAME__INSTEAD_FILE_NAME/
 redirect_from:
   - /docs/get-ready-to-deploy
+  - /docs/get-ready-to-deploy/
 toc: true
 ---
 Google Container Engine is a powerful cluster manager and orchestration system for running your Docker containers built on Kubernetes. We’ve setup a deep integration with Google Container Engine that enables to create streamlined deployment to Kubernetes as part of a CI/CD pipeline.


### PR DESCRIPTION
- fixed redirect for /docs/get-ready-to-deploy