### PR TITLE
Redirects hotfix

### DIFF
--- a/_docs/configure-ci-cd-pipeline/build-status.md
+++ b/_docs/configure-ci-cd-pipeline/build-status.md
@@ -5,7 +5,7 @@ group: configure-ci-cd-pipeline
 toc: true
 redirect_from:
   - /docs/build-status
-  - /docs/build-status
+  - /docs/build-status/
 ---
 ## Overview
 


### PR DESCRIPTION
- fixed redirection from `https://codefresh.io/docs/docs/build-status`  is broken