### PR TITLE
Fixed broken link for sharing a test environment

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -233,7 +233,7 @@
     - title: Test Your Feature
       url: "/test-your-feature"
     - title: Share Your Environment with Your Team
-      url: "/share-environment-with-your-test"
+      url: "/share-your-environment-with-your-team"
     - title: Composition Service Discovery (Experimental)
       url: "/composition-service-discovery"
     - title: Useful compositions

--- a/_docs/on-demand-test-environment/share-your-environment-with-your-team.md
+++ b/_docs/on-demand-test-environment/share-your-environment-with-your-team.md
@@ -6,6 +6,9 @@ toc: true
 redirect_from:
   - /docs/share-environment-with-your-test
   - /docs/share-environment-with-your-test/
+  - /docs/on-demand-test-environment/share-environment-with-your-test
+  - /docs/on-demand-test-environment/share-environment-with-your-test/
+ 
 ---
 After you successfully spin up a composition, click the **Environments** view icon in the left pane, to view the record for the running environment and all containers for the environment.
 


### PR DESCRIPTION
The name of the link was wrong in the first place. Kept the old name as well for user that might have bookmarks