### PR TITLE
Update composition step docs

### DIFF
--- a/_docs/codefresh-yaml/steps/composition.md
+++ b/_docs/codefresh-yaml/steps/composition.md
@@ -295,7 +295,8 @@ In this pipeline:
 
 Therefore, in this pipeline you can see both ways of data sharing, bringing files into a composition and getting results out of it. Notice that we need to mount the shared volume only in the composition services. The freestyle steps automatically mount `/codefresh/volume` on their own.
 
->Note: it is not compulsory to mount the shared volume in all services of a composition. Only those that actually use it for file transfer, should mount it.
+
+>Note: In order to mount the shared volume in one of your composition services, you must mount it in the `composition_candidate` also. It is not compulsory to mount the shared volume in all services of a composition. Only those that actually use it for file transfer, should mount it.
 
 
 ## Composition variables versus environment variables


### PR DESCRIPTION
I noticed error when trying to use shared volume only in a service, and not on the composition candidate. I think this note can make it more clear that you need it mounted on the composition candidate