### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The site is automatically deployed when commits land in `master`, hosted by at h
 
 1. Install Ruby and `bundler`, `jekyll` and other Ruby dependencies with `bundle install`.
 2. Run `npm install` to install Node.js dependencies.
-3. Run `npm run css` (or a specific NPM script) to rebuild distributed CSS and JavaScript files, as well as our docs assets.
+3. Run `npm run css` (or a specific npm script) to rebuild distributed CSS and JavaScript files, as well as our docs assets.
 4. From the root directory, run `npm run docs-serve-dev` in the command line.
 5. Open `http://localhost:19002` in your browser, and voila.
 
@@ -18,4 +18,4 @@ The site is automatically deployed when commits land in `master`, hosted by at h
 
 1. Install [docker-compose](https://docs.docker.com/compose/)
 1. Run `docker-compose up`
-1. Open `http://localhost:3131` in your browser, and voila! 
+1. Open `http://localhost:3131` in your browser, and voila!

--- a/_data/home-content.yml
+++ b/_data/home-content.yml
@@ -208,7 +208,7 @@
     localurl: /docs/integrations/jenkins-integration/
   - title: Slack integration
     localurl: /docs/integrations/notifications/slack-integration/
-  - title: Github actions
+  - title: GitHub Actions
     new: true
     localurl: /docs/integrations/github-actions/
   - title: Jira integration

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -384,7 +384,7 @@
       sub-pages:
         - title: Slack
           url: "/slack-integration"
-    - title: Github actions
+    - title: GitHub Actions
       url: "/github-actions"
     - title: Jira Integration
       url: "/jira-integration"

--- a/_docs/codefresh-yaml/advanced-workflows.md
+++ b/_docs/codefresh-yaml/advanced-workflows.md
@@ -165,7 +165,7 @@ As you can see we have also marked the steps with [stages]({{site.baseurl}}/docs
 
 All types of steps can by placed inside a parallel phase. Another common use case would be the parallel execution of [freestyle steps]({{site.baseurl}}/docs/codefresh-yaml/steps/freestyle/) for unit/integration tests.
 
-Let's say that you have a Docker image with a Python back-end and a Javascript front-end. You could run both types of tests in parallel with the following yaml syntax:
+Let's say that you have a Docker image with a Python back-end and a JavaScript front-end. You could run both types of tests in parallel with the following yaml syntax:
 
 `YAML`
 {% highlight yaml %}

--- a/_docs/codefresh-yaml/steps.md
+++ b/_docs/codefresh-yaml/steps.md
@@ -992,7 +992,7 @@ checkout_many_projects:
 {% endraw %}
 {% endhighlight %}
 
-The Github projects are passed as an array, so if we want to check out an additional project, we simply add items to that array.
+The GitHub projects are passed as an array, so if we want to check out an additional project, we simply add items to that array.
 
 Here is the [step specification](https://github.com/kostis-codefresh/step-examples/blob/master/multi-clone/multi-clone-step.yml):
 

--- a/_docs/codefresh-yaml/steps/git-clone.md
+++ b/_docs/codefresh-yaml/steps/git-clone.md
@@ -112,7 +112,7 @@ caption="Example git integrations"
 max-width="40%"
 %}
 
-Here is an example for an integration with the Gitlab provider already connected:
+Here is an example for an integration with the GitLab provider already connected:
 
 `codefresh.yml`
 {% highlight yaml %}
@@ -277,7 +277,7 @@ Here is an example for GitHub
 version: '1.0'
 steps:
   get_git_token:
-    title: Reading Github token
+    title: Reading GitHub token
     image: codefresh/cli
     commands:
       - cf_export GITHUB_TOKEN=$(codefresh get context github --decrypt -o yaml | yq -y .spec.data.auth.password)

--- a/_docs/codefresh-yaml/variables.md
+++ b/_docs/codefresh-yaml/variables.md
@@ -88,11 +88,11 @@ All system provided variables will also be automatically injected to any freesty
 | {% raw %}`${{CF_REPO_NAME}}`{% endraw %}          | Repository name. |
 | {% raw %}`${{CF_BRANCH}}`{% endraw %}             | Branch name (or Tag depending on the payload json) of the Git repository of the main pipeline, at the time of execution. <br/>You can also use {% raw %}`${{CF_BRANCH_TAG_NORMALIZED}}`{% endraw %} to get the branch name normalized. It will be without any chars that are illegal in case the branch name were to be used as the Docker image tag name. You can also use {% raw %}`${{CF_BRANCH_TAG_NORMALIZED_LOWER_CASE}}`{% endraw %} to force lowercase. |
 | {% raw %}`${{CF_BASE_BRANCH}}`{% endraw %}      | The base branch used during creation of Tag |
-| {% raw %}`${{CF_PULL_REQUEST_ACTION}}`{% endraw %}      | The pull request action. Values are those defined by your Git provider such as [Github](https://developer.github.com/webhooks/), [Gitlab](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html), [Bitbucket](https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html) etc. |
+| {% raw %}`${{CF_PULL_REQUEST_ACTION}}`{% endraw %}      | The pull request action. Values are those defined by your Git provider such as [GitHub](https://developer.github.com/webhooks/), [GitLab](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html), [Bitbucket](https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html) etc. |
 | {% raw %}`${{CF_PULL_REQUEST_TARGET}}`{% endraw %}      | The pull request target branch |
 | {% raw %}`${{CF_PULL_REQUEST_NUMBER}}`{% endraw %}      | The pull request number |
 | {% raw %}`${{CF_PULL_REQUEST_ID}}`{% endraw %}      | The pull request id |
-| {% raw %}`${{CF_PULL_REQUEST_LABELS}}`{% endraw %}      | The labels of pull request (Github and Gitlab only) |
+| {% raw %}`${{CF_PULL_REQUEST_LABELS}}`{% endraw %}      | The labels of pull request (GitHub and GitLab only) |
 | {% raw %}`${{CF_COMMIT_AUTHOR}}`{% endraw %}      | Commit author.                                                                                              |
 | {% raw %}`${{CF_BUILD_INITIATOR}}`{% endraw %}      | The person (username) that started the build. If the build was started by a Git webhook (e.g. from a Pull request) it will hold the webhook user. Notice that if a build is restarted manually it will always hold the username of the person that restarted it.                                                                                                                                                                                                                                                                                    |
 | {% raw %}`${{CF_ACCOUNT}}`{% endraw %}         | Codefresh account for this build |
@@ -153,8 +153,8 @@ You can set a [trigger]({{site.baseurl}}/docs/configure-ci-cd-pipeline/triggers/
 {: .table .table-bordered .table-hover}
 | Variable        | Description                                            |
 | --------------- | ------------------------------------------------------ |
-| {% raw %}`${{CF_RELEASE_NAME}}`{% endraw %}     | Github release title   |
-| {% raw %}`${{CF_RELEASE_TAG}}`{% endraw %}      | GIT tag version   |
+| {% raw %}`${{CF_RELEASE_NAME}}`{% endraw %}     | GitHub release title   |
+| {% raw %}`${{CF_RELEASE_TAG}}`{% endraw %}      | Git tag version   |
 | {% raw %}`${{CF_RELEASE_ID}}`{% endraw %}       | Internal ID for this release   |
 | {% raw %}`${{CF_PRERELEASE_FLAG}}`{% endraw %}  | true if the release if marked as non-production ready, false if it is ready for production   |
 

--- a/_docs/configure-ci-cd-pipeline/triggers/git-triggers.md
+++ b/_docs/configure-ci-cd-pipeline/triggers/git-triggers.md
@@ -133,7 +133,7 @@ Once that is done, Codefresh will launch your pipeline against the Pull Request.
 When supporting building of pull requests from forks there are a few "gotchas" to look out for:
 
 * Only comments made by repository owners and [collaborators](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/adding-outside-collaborators-to-repositories-in-your-organization) will result in the pipeline being triggered
-* Only git pushes by collaborators within the Github organization will result in the pipeline being triggered
+* Only git pushes by collaborators within the GitHub organization will result in the pipeline being triggered
 * If the repository is in a GitHub organization, comments made by private members of the organization will not activate the trigger, even if they are set as an owner or collaborator.
 * The *Pull request comment added* checkbox should likely be the only one checked, or your pipeline may trigger on other events that you don't anticipate.
 
@@ -143,7 +143,7 @@ The *modified files* field is a very powerful Codefresh feature that allows you 
 files affected by a commit are in a specific folder (or match a specific naming pattern). This means that
 you can have a big GIT repository with multiple projects and build only the parts that actually change.
 
->Currently the field *modified files* is available only for GitHub, Gitlab and Bitbucket SAAS repositories, since they are the only GIT providers
+>Currently the field *modified files* is available only for GitHub, GitLab and Bitbucket SAAS repositories, since they are the only GIT providers
 that send this information in the webhook. We will support other GIT providers as soon as they add the respective feature. Also, the *modified files* field is only available for push events (i.e. not PR open events), since GIT providers only send it on these events.
 
 ### Using the Modified files field to constrain triggers to specific folder/files

--- a/_docs/deploy-your-containers/google-container-engine-gke-kubernetes.md
+++ b/_docs/deploy-your-containers/google-container-engine-gke-kubernetes.md
@@ -21,7 +21,7 @@ The deployment script makes the following assumptions about your application and
 {{site.data.callout.callout_info}}
 ##### Try this example
 
-Just head over to the example [__repository__](https://github.com/codefreshdemo/cf-deploy-kubernetes){:target="_blank"} in Github.
+Just head over to the example [__repository__](https://github.com/codefreshdemo/cf-deploy-kubernetes){:target="_blank"} in GitHub.
 {{site.data.callout.end}}
 
 {{site.data.callout.callout_info}}

--- a/_docs/enterprise/behind-the-firewall.md
+++ b/_docs/enterprise/behind-the-firewall.md
@@ -162,14 +162,14 @@ Once that is done, Codefresh will show you the webhook endpoint along with a sec
 This concludes the setup on the Codefresh side. The final step is create a webhook call on the side of your GIT provider.
 The instructions are different per GIT provider:
 
-* [Github webhooks](https://developer.github.com/webhooks/)
-* [Gitlab webhooks](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html)
+* [GitHub webhooks](https://developer.github.com/webhooks/)
+* [GitLab webhooks](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html)
 * [Stash webhooks](https://confluence.atlassian.com/bitbucketserver/managing-webhooks-in-bitbucket-server-938025878.html)
 
 In all cases make sure that the payload is JSON, because this is what Codefresh expects.
 
 * For GitHub the events monitored should be `Pull requests` and `Pushes`.
-* For Gitlab the events monitored should be `Push events`,`Tag push events` and `Merge request events`.
+* For GitLab the events monitored should be `Push events`,`Tag push events` and `Merge request events`.
 
 After the setup is finished, the Codefresh pipeline will be executed every time a git event happens.
 

--- a/_docs/enterprise/codefresh-on-prem.md
+++ b/_docs/enterprise/codefresh-on-prem.md
@@ -164,7 +164,7 @@ You will also need to modify the `config.yaml` for `kfci` by setting `skipCRD: t
 
 `kcfi` is a single binary and doesn’t have any dependencies.
 
-Download the binary from [Github](https://github.com/codefresh-io/kcfi/releases).
+Download the binary from [GitHub](https://github.com/codefresh-io/kcfi/releases).
 >Note: Darwin is for OSX
 
 Extract the file you just downloaded.

--- a/_docs/enterprise/codefresh-runner.md
+++ b/_docs/enterprise/codefresh-runner.md
@@ -486,7 +486,7 @@ Installation of the Codefresh runner on a Kubernetes cluster is also setting up 
 Each one has own RBAC needs and therefore, expected created roles(and cluster-roles)
 
 
-You can see the exact resource descriptors [on Github](https://github.com/codefresh-io/venona/tree/master/venonactl/pkg/templates/kubernetes).
+You can see the exact resource descriptors [on GitHub](https://github.com/codefresh-io/venona/tree/master/venonactl/pkg/templates/kubernetes).
 
 Here is a list of the resources that are created during a Runner installation:
 

--- a/_docs/enterprise/single-sign-on.md
+++ b/_docs/enterprise/single-sign-on.md
@@ -16,7 +16,7 @@ toc: true
 
   - **A security Assertion Markup Language 2.0 (SAML 2.0)** compliant Identity Provider (IdP) that is configured to communicate with Codefresh Service Provider (SP). For example, ADFS, Auth0, Okta and Ping Identity. 
   
-  - **OpenID Connect (OAuth 2.0)** identity management. For example, Google, GitHub, Bitbucket and Gitlab.
+  - **OpenID Connect (OAuth 2.0)** identity management. For example, Google, GitHub, Bitbucket and GitLab.
   
   This enables seamless SSO from a browser, by asserting the identity of the user to Codefresh.
 

--- a/_docs/enterprise/single-sign-on/sso-setup-oauth2.md
+++ b/_docs/enterprise/single-sign-on/sso-setup-oauth2.md
@@ -8,7 +8,7 @@ redirect_from:
 toc: true
 ---
 
-Codefresh natively supports login using GitHub, Bitbucket and Gitlab using OpenID Connect (OAUTH 2.0) protocol. This guide will review how to add additional SSO integrations based on OAUTH 2.0 as part of Codefresh Enterprise plan.
+Codefresh natively supports login using GitHub, Bitbucket and GitLab using OpenID Connect (OAUTH 2.0) protocol. This guide will review how to add additional SSO integrations based on OAUTH 2.0 as part of Codefresh Enterprise plan.
 
   
 ## Prerequisites

--- a/_docs/getting-started/create-a-basic-pipeline.md
+++ b/_docs/getting-started/create-a-basic-pipeline.md
@@ -61,7 +61,7 @@ After some brief time, the repository should appear in your own GitHub account.
 Now you are ready to start building code with Codefresh!
 
 
-> Codefresh supports Gitlab, Bitbucket and Azure GIT repositories apart from GitHub. The
+> Codefresh supports GitLab, Bitbucket and Azure GIT repositories apart from GitHub. The
 same principles presented in this tutorial apply for all Git providers.
 
 

--- a/_docs/getting-started/create-a-codefresh-account.md
+++ b/_docs/getting-started/create-a-codefresh-account.md
@@ -25,7 +25,7 @@ max-width="90%"
 ## 1. Select your Identity Provider
 
 First, navigate to the [Codefresh Sign Up page](https://g.codefresh.io/signup).  
-Codefresh currently supports GitHub, Bitbucket and Gitlab as a Git provider. If you are using another Git provider
+Codefresh currently supports GitHub, Bitbucket and GitLab as a Git provider. If you are using another Git provider
 please [contact us](https://codefresh.io/contact-us/) to discuss alternative options. You can also select
 Azure or Google as an identity provider.
 
@@ -61,8 +61,8 @@ image.html
 lightbox="true" 
 file="/images/getting-started/create-account/github-authorize.png" 
 url="/images/getting-started/create-account/github-authorize.png"
-alt="Github authorization page" 
-caption="Github authorization page (click image to enlarge)" 
+alt="GitHub authorization page" 
+caption="GitHub authorization page (click image to enlarge)" 
 max-width="50%" 
 %}
 
@@ -79,7 +79,7 @@ caption="Bitbucket authorization page (click image to enlarge)"
 max-width="50%" 
 %}
 
-Finally if you use Gitlab you will see the permissions window shown below. Click the button labeled *Authorize* to continue.
+Finally if you use GitLab you will see the permissions window shown below. Click the button labeled *Authorize* to continue.
 
 
 {% include 
@@ -87,8 +87,8 @@ image.html
 lightbox="true" 
 file="/images/getting-started/create-account/gitlab-authorize.png" 
 url="/images/getting-started/create-account/gitlab-authorize.png"
-alt="Gitlab authorization page" 
-caption="Gitlab authorization page (click image to enlarge)" 
+alt="GitLab authorization page" 
+caption="GitLab authorization page (click image to enlarge)" 
 max-width="50%" 
 %}
 

--- a/_docs/getting-started/faq.md
+++ b/_docs/getting-started/faq.md
@@ -100,7 +100,7 @@ A. Yes, all pipelines can be stored in a git repository (the same one as the app
 A. For basic usage, feel free to use the [shared configuration]({{site.baseurl}}/docs/configure-ci-cd-pipeline/shared-configuration/) facility. For production grade security we suggest a dedicated solution such as [Hashicorp Vault](https://www.vaultproject.io/). We offer a [vault plugin](https://codefresh.io/steps/step/vault) for this purpose.
 
 **Q. Can I call external service X in a pipeline?**    
-A. Yes, everything that has an API or CLI can be called in a Codefresh pipeline (Artifactory/S3/Slack/Sonarqube/Twistlock/Codecov etc)
+A. Yes, everything that has an API or CLI can be called in a Codefresh pipeline (Artifactory/S3/Slack/SonarQube/Twistlock/Codecov etc)
 
 
 ## Deployment features

--- a/_docs/how-to-guides/implementing-canary-release-with-kubernetes.md
+++ b/_docs/how-to-guides/implementing-canary-release-with-kubernetes.md
@@ -24,7 +24,7 @@ Our goal in this example is to implement the trunk-based development and deliver
 
 The Canary Pipeline
 
-First pipeline is the canary. It gets triggered by a Github webhook for each new master commit and is configured to use [codefresh-canary.yml](https://github.com/Codefresh-Examples/Examples/blob/master/canary-release/codefresh-canary.yml) as its flow definition.
+First pipeline is the canary. It gets triggered by a GitHub webhook for each new master commit and is configured to use [codefresh-canary.yml](https://github.com/Codefresh-Examples/Examples/blob/master/canary-release/codefresh-canary.yml) as its flow definition.
 
 We first build and push the images for the application and for test execution. Steps appropriately named _buildAppImage, pushAppImage, buildTestImage and pushTestImage_ take care of that:
 

--- a/_docs/incubation/arm-support.md
+++ b/_docs/incubation/arm-support.md
@@ -127,5 +127,5 @@ In summary, the workflow for ARM images is exactly the same as the usual Linux/x
 ## What to read next
 
 * [Windows container support]({{site.baseurl}}/docs/incubation/windows-beta/)
-* [MacOSX and iOS builds]({{site.baseurl}}/docs/incubation/osx-ios-builds/)
+* [macOS and iOS builds]({{site.baseurl}}/docs/incubation/osx-ios-builds/)
 

--- a/_docs/integrations/codefresh-api.md
+++ b/_docs/integrations/codefresh-api.md
@@ -81,7 +81,7 @@ The following resources can be targeted with the API:
 * *Build* - Get/change [build status]({{site.baseurl}}/docs/configure-ci-cd-pipeline/monitoring-pipelines/)
 * *Cluster* - [Access control]({{site.baseurl}}/docs/enterprise/access-control/) for [Kubernetes clusters]({{site.baseurl}}/docs/deploy-to-kubernetes/manage-kubernetes/)
 * *Environments-v2* - Read/Write [Environment Dashboard]({{site.baseurl}}/docs/deploy-to-kubernetes/environment-dashboard/) information
-* *Github Action* - Run [Github actions inside Codefresh pipelines]({{site.baseurl}}/docs/integrations/github-actions/)
+* *GitHub Actions* - Run [GitHub Actions inside Codefresh pipelines]({{site.baseurl}}/docs/integrations/github-actions/)
 * *Pipeline* - [Access control]({{site.baseurl}}/docs/enterprise/access-control/) for [pipelines]({{site.baseurl}}/docs/configure-ci-cd-pipeline/introduction-to-codefresh-pipelines/)
 * *Repos* - Refers to [Git repositories]({{site.baseurl}}/docs/integrations/git-providers/)
 * *Step Type* - Refers to [custom pipeline steps]({{site.baseurl}}/docs/codefresh-yaml/steps/#creating-a-typed-codefresh-plugin)

--- a/_docs/integrations/git-providers.md
+++ b/_docs/integrations/git-providers.md
@@ -74,8 +74,8 @@ For SSH, paste your **raw**, private key into the SSH Key text box and click sav
 
 For more information on generating SSH keys and adding your public key to your VCS provider, see its official documentation:
  
-- [Github documentation](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).
-- [Gitlab documentation](https://docs.gitlab.com/ee/ssh/#generating-a-new-ssh-key-pair)
+- [GitHub documentation](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).
+- [GitLab documentation](https://docs.gitlab.com/ee/ssh/#generating-a-new-ssh-key-pair)
 - [Bitbucket documentation](https://confluence.atlassian.com/bitbucket/set-up-an-ssh-key-728138079.html)
 - [Azure documentation](https://docs.microsoft.com/en-us/azure/devops/repos/git/use-ssh-keys-to-authenticate?view=azure-devops&tabs=current-page)
 
@@ -107,16 +107,16 @@ lightbox="true"
 file="/images/integrations/git/github-required-scopes.png" 
 url="/images/integrations/git/github-required-scopes.png"
 max-width="40%"
-caption="Github permissions"
-alt="Github permissions"
+caption="GitHub permissions"
+alt="GitHub permissions"
 %}
 
-For Github on-premise you also need to provide the URL of the GitHub server in your organization.
+For GitHub on-premise you also need to provide the URL of the GitHub server in your organization.
 
-## Gitlab
+## GitLab
 
-For the **OAuth2 method** you only need to enable private repository access, enter a name for your connection and click *Save*. Then accept the permissions dialog. This is the easiest and recommended way to integrate Gitlab. Notice that if
-you used Gitlab when you [created your Codefresh account]({{site.baseurl}}/docs/getting-started/create-a-codefresh-account/), this integration is already setup for you.
+For the **OAuth2 method** you only need to enable private repository access, enter a name for your connection and click *Save*. Then accept the permissions dialog. This is the easiest and recommended way to integrate GitLab. Notice that if
+you used GitLab when you [created your Codefresh account]({{site.baseurl}}/docs/getting-started/create-a-codefresh-account/), this integration is already setup for you.
 
 For the **Access Key** method you need:
 
@@ -124,15 +124,15 @@ For the **Access Key** method you need:
 * An access token/key
 
 
-To create an access token, go to your Gitlab *settings* and select the *Access tokens* options.
-For more information see the [Gitlab Documentation page](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html){:target="_blank"}
+To create an access token, go to your GitLab *settings* and select the *Access tokens* options.
+For more information see the [GitLab Documentation page](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html){:target="_blank"}
 
-The name you enter in order to create the token in the Gitlab UI is completely arbitrary (use "Codefresh" for an example)
+The name you enter in order to create the token in the GitLab UI is completely arbitrary (use "Codefresh" for an example)
 
 Once you have the token, paste it in the Codefresh UI and click *Test connection*. If everything is OK can
 now save the git integration.
 
-For Gitlab on-premise you also need to provide the URL of the Gitlab server in your organization.
+For GitLab on-premise you also need to provide the URL of the GitLab server in your organization.
 
 ## Bitbucket
 

--- a/_docs/integrations/github-actions.md
+++ b/_docs/integrations/github-actions.md
@@ -1,12 +1,12 @@
 ---
-title: "Github actions in Codefresh pipelines"
-description: "Using the Github action converter"
+title: "GitHub Actions in Codefresh pipelines"
+description: "Using the GitHub action converter"
 group: integrations
 
 toc: true
 ---
 
-[Github actions](https://github.com/features/actions) are a set of reusable workflows that can be composed to create automation sequences for Github projects. Github actions are supported natively with Github, but you can also use them in Codefresh pipelines by automatically converting them to [Codefresh pipeline steps]({{site.baseurl}}/docs/codefresh-yaml/steps/).
+[GitHub Actions](https://github.com/features/actions) are a set of reusable workflows that can be composed to create automation sequences for GitHub projects. GitHub Actions are supported natively with GitHub, but you can also use them in Codefresh pipelines by automatically converting them to [Codefresh pipeline steps]({{site.baseurl}}/docs/codefresh-yaml/steps/).
 
 
 {% include image.html 
@@ -14,38 +14,38 @@ lightbox="true"
 file="/images/integrations/github-actions/github-actions-marketplace.png" 
 url="/images/integrations/github-actions/github-actions-marketplace.png"
 max-width="60%"
-caption="Github Actions Marketplace"
-alt="Github Actions Marketplace"
+caption="GitHub Actions Marketplace"
+alt="GitHub Actions Marketplace"
 %}
 
-By using Github actions in your marketplace you have the following benefits:
+By using GitHub Actions in your marketplace you have the following benefits:
 
  * access to a vast catalog of reusable pipeline components
- * the ability to use Github actions with any provider, as Codefresh supports [Bitbucket, Gitlab, Azure Git etc.]({{site.baseurl}}/docs/integrations/git-providers/)
+ * the ability to use GitHub actions with any provider, as Codefresh supports [Bitbucket, GitLab, Azure Git etc.]({{site.baseurl}}/docs/integrations/git-providers/)
 
 
 ## Prerequisites
 
-In order to use a Github action in Codefresh you need to make sure that the following apply:
+In order to use a GitHub action in Codefresh you need to make sure that the following apply:
 
-1. The [Github action](https://github.com/marketplace?type=actions) you have selected is Docker based and has a self-contained and valid Dockerfile
-1. You have read the documentation of the Github action and know what arguments/input it requires
+1. The [GitHub action](https://github.com/marketplace?type=actions) you have selected is Docker based and has a self-contained and valid Dockerfile
+1. You have read the documentation of the GitHub action and know what arguments/input it requires
 
 
-Also notice that since Github actions are created by the community, it is your responsibility to filter and curate any Github actions that you wish to use in Codefresh pipelines. If for example you use a Github action, and then it is removed by its creator, the Codefresh pipeline that uses it will break as well.
+Also notice that since GitHub Actions are created by the community, it is your responsibility to filter and curate any GitHub actions that you wish to use in Codefresh pipelines. If for example you use a GitHub action, and then it is removed by its creator, the Codefresh pipeline that uses it will break as well.
 
-> We suggest you first use a Github action in a Github workflow, in order to understand its requirements, before you use it in a Codefresh pipeline.
+> We suggest you first use a GitHub action in a GitHub workflow, in order to understand its requirements, before you use it in a Codefresh pipeline.
 
 ## How it works
 
 Codefresh offers a github-action-to-codefresh step converter. This converter has two functions
 
-1. When you create your pipeline it will analyze the Github action and try to find what arguments it requires. You must then fill the values needed by yourself
-1. When the pipeline runs, it will automatically find the Dockerfile of the Github action, build it and make available the docker image in any subsequent step in the same pipeline.
+1. When you create your pipeline it will analyze the GitHub action and try to find what arguments it requires. You must then fill the values needed by yourself
+1. When the pipeline runs, it will automatically find the Dockerfile of the GitHub action, build it and make available the docker image in any subsequent step in the same pipeline.
 
-All this process is automatic. You just need to make sure that all arguments/inputs of the Github action as provided using [pipeline variables]({{site.baseurl}}/docs/configure-ci-cd-pipeline/pipelines/#creating-new-pipelines), [shared configuration]({{site.baseurl}}/docs/configure-ci-cd-pipeline/shared-configuration/) or any other standard mechanism you already use in Codefresh.
+All this process is automatic. You just need to make sure that all arguments/inputs of the GitHub action as provided using [pipeline variables]({{site.baseurl}}/docs/configure-ci-cd-pipeline/pipelines/#creating-new-pipelines), [shared configuration]({{site.baseurl}}/docs/configure-ci-cd-pipeline/shared-configuration/) or any other standard mechanism you already use in Codefresh.
 
-## Inserting a Github action in Codefresh pipeline
+## Inserting a GitHub action in Codefresh pipeline
 
 [Create a Codefresh pipeline]({{site.baseurl}}/docs/configure-ci-cd-pipeline/pipelines/#creating-new-pipelines) by visiting the pipeline editor. On the right hand panel in the step tab, search for `actions`.
 
@@ -58,33 +58,33 @@ caption="Step browser"
 alt="Step browser"
 %}
 
-From the result choose the *Github actions* step with the green check mark. From the dialog that will appear you will see a browser for Github actions. Scroll down to find the Github action that you want to use or enter a keyword to filter the list
+From the result choose the *GitHub Actions* step with the green check mark. From the dialog that will appear you will see a browser for GitHub actions. Scroll down to find the GitHub action that you want to use or enter a keyword to filter the list
 
 {% include image.html 
 lightbox="true" 
 file="/images/integrations/github-actions/select-github-action.png" 
 url="/images/integrations/github-actions/select-github-action.png"
 max-width="70%"
-caption="Select Github action"
-alt="Select Github action"
+caption="Select GitHub action"
+alt="Select GitHub action"
 %}
 
-Then click on the Github action that you want to use in your pipeline. On the right hand side Codefresh will present that [YAML]({{site.baseurl}}/docs/codefresh-yaml/what-is-the-codefresh-yaml/)  step that you need to insert in your pipeline. 
+Then click on the GitHub action that you want to use in your pipeline. On the right hand side Codefresh will present that [YAML]({{site.baseurl}}/docs/codefresh-yaml/what-is-the-codefresh-yaml/)  step that you need to insert in your pipeline. 
 
 {% include image.html 
 lightbox="true" 
 file="/images/integrations/github-actions/snyk-action-arguments.png" 
 url="/images/integrations/github-actions/snyk-action-arguments.png"
 max-width="70%"
-caption="Using the Snyk Github action"
-alt="Using the Snyk Github action"
+caption="Using the Snyk GitHub action"
+alt="Using the Snyk GitHub action"
 %}
 
 This YAML snippet is a template and you need to fill the `env` block under the `arguments` block:
-The required environment variables are specific to each Github action so check the documentation of the action itself.
+The required environment variables are specific to each GitHub action so check the documentation of the action itself.
 
 
-In the example above we are using the Snyk Github action. By visiting the [documentation page](https://github.com/marketplace/actions/snyk-cli-action) we find that this action expects a `SNYK_TOKEN` as input.
+In the example above we are using the Snyk GitHub action. By visiting the [documentation page](https://github.com/marketplace/actions/snyk-cli-action) we find that this action expects a `SNYK_TOKEN` as input.
 
 We therefore add the token as a pipeline variable:
 
@@ -116,11 +116,11 @@ steps:
 {% endraw %}            
 {% endhighlight %}
 
-The `cmd` property is specific to each Github action and in the case of Snyk we say we want to scan an alpine image for security issues.
+The `cmd` property is specific to each GitHub action and in the case of Snyk we say we want to scan an alpine image for security issues.
 
 
 
-## Running a Codefresh pipeline with Github actions
+## Running a Codefresh pipeline with GitHub Actions
 
 
 You can run the pipeline as any other Codefresh pipeline.
@@ -130,20 +130,20 @@ lightbox="true"
 file="/images/integrations/github-actions/github-action-pipeline.png" 
 url="/images/integrations/github-actions/github-action-pipeline.png"
 max-width="80%"
-caption="Using Github actions in a Codefresh pipeline"
-alt="Using Github actions in a Codefresh pipeline"
+caption="Using GitHub Actions in a Codefresh pipeline"
+alt="Using GitHub Actions in a Codefresh pipeline"
 %}
 
 
-Once the pipeline reaches the Github action step, the converter will do automatically the following
+Once the pipeline reaches the GitHub action step, the converter will do automatically the following
 
-1. Find the Dockerfile of the Github action
+1. Find the Dockerfile of the GitHub action
 1. Build the Dockerfile
 1. Take the resulting image and insert it as Codefresh step
-1. Pass the environment variables as arguments to the Github action
+1. Pass the environment variables as arguments to the GitHub action
 1. Run the `cmd` command
 
-If you have issues please contact us (or open a support ticket) and let us know which Github action you are trying to use and what is the URL of the Codefresh build that fails.
+If you have issues please contact us (or open a support ticket) and let us know which GitHub action you are trying to use and what is the URL of the Codefresh build that fails.
 
 
 ## What to read next

--- a/_docs/learn-by-example/general/selenium-test.md
+++ b/_docs/learn-by-example/general/selenium-test.md
@@ -71,5 +71,5 @@ max-width="40%"
 {{site.data.callout.callout_info}}
 ##### Example
 
-Just head over to the example [__repository__](https://github.com/codefreshdemo/cf-example-selenium-test){:target="_blank"} in Github and follow the instructions there. 
+Just head over to the example [__repository__](https://github.com/codefreshdemo/cf-example-selenium-test){:target="_blank"} in GitHub and follow the instructions there. 
 {{site.data.callout.end}}

--- a/_docs/learn-by-example/golang/goreleaser.md
+++ b/_docs/learn-by-example/golang/goreleaser.md
@@ -45,7 +45,7 @@ More typically however you also need to provide a GitHub token so that GitHub re
 ## Create a CI pipeline that compiles/releases Go
 
 In most cases you want to just reuse the Git integration already defined in Codefresh.
-This [pipeline](https://github.com/codefresh-contrib/goreleaser-sample-app/blob/master/codefresh.yml) is using the Github token from [Git integration]({{site.baseurl}}/docs/integrations/git-providers/) in order to allow github access.
+This [pipeline](https://github.com/codefresh-contrib/goreleaser-sample-app/blob/master/codefresh.yml) is using the GitHub token from [Git integration]({{site.baseurl}}/docs/integrations/git-providers/) in order to allow github access.
 
  `codefresh.yml`
 {% highlight yaml %}
@@ -69,7 +69,7 @@ steps:
     commands:
       - go build
   GetGitToken:
-    title: Reading Github token
+    title: Reading GitHub token
     stage: release
     image: codefresh/cli
     commands:
@@ -84,7 +84,7 @@ steps:
 {% endhighlight %}
 
 Note that GoReleaser [requires a GitHub API token](https://goreleaser.com/environment/) (`GITHUB_TOKEN`) with the `repo` scope to deploy artifacts to GitHub.
-Here we use [cf_export]({{site.baseurl}}/docs/codefresh-yaml/variables/#exporting-environment-variables-from-a-freestyle-step) and the [codefresh CLI](https://codefresh-io.github.io/cli/) in order to ask Codefresh about the existing token (that was used in git integrations). In your case you need to change `github-1` with the name of your [Github integration]({{site.baseurl}}/docs/integrations/git-providers/).
+Here we use [cf_export]({{site.baseurl}}/docs/codefresh-yaml/variables/#exporting-environment-variables-from-a-freestyle-step) and the [codefresh CLI](https://codefresh-io.github.io/cli/) in order to ask Codefresh about the existing token (that was used in git integrations). In your case you need to change `github-1` with the name of your [GitHub integration]({{site.baseurl}}/docs/integrations/git-providers/).
 
 It also possible to pass a GITHUB_TOKEN directly in the pipeline, if you don't want to re-use the existing one. This is an alternative way of allowing Goreleaser to create GitHub releases.
 

--- a/_docs/learn-by-example/nodejs/lets-chat.md
+++ b/_docs/learn-by-example/nodejs/lets-chat.md
@@ -59,5 +59,5 @@ steps:
 {{site.data.callout.callout_info}}
 ##### Example
 
-Just head over to the example [__repository__](https://github.com/codefreshdemo/demochat){:target="_blank"} in Github and follow the instructions there. 
+Just head over to the example [__repository__](https://github.com/codefreshdemo/demochat){:target="_blank"} in GitHub and follow the instructions there. 
 {{site.data.callout.end}}

--- a/_docs/learn-by-example/nodejs/react.md
+++ b/_docs/learn-by-example/nodejs/react.md
@@ -50,7 +50,7 @@ This docker build does the following:
 1. Starts from the Node/Yarn image
 1. Copies the dependencies inside the container
 1. Copies the source code and creates all static files
-1. Discards the Node.js image with all the Javascript libraries
+1. Discards the Node.js image with all the JavaScript libraries
 1. Starts again from the nginx image and copies **static build result** created before
 
 The resulting is very small, as it contains only packaged/minified files.

--- a/_docs/learn-by-example/python/voting-app.md
+++ b/_docs/learn-by-example/python/voting-app.md
@@ -23,7 +23,7 @@ steps:
     image: codefresh/buildpacks:nodejs-5
     working-directory : ${{initial-clone}}
     commands:
-      - echo Installing NPM modules silent
+      - echo Installing npm modules silent
       - npm install
       - gulp test
       - echo $(date)

--- a/_docs/learn-by-example/scala/scala-hello-world.md
+++ b/_docs/learn-by-example/scala/scala-hello-world.md
@@ -21,7 +21,7 @@ We’ll help you get up to speed with basic functionality such as: compiling, bu
 
 This project uses `Scala` to build an application which will eventually become a distributable Docker image.
 
-You can find the example application on [Github](https://github.com/codefresh-contrib/scala-hello-world-app). 
+You can find the example application on [GitHub](https://github.com/codefresh-contrib/scala-hello-world-app). 
 
 There are two pipeline examples provided in this tutorial:
 

--- a/_docs/new-helm/helm-best-practices.md
+++ b/_docs/new-helm/helm-best-practices.md
@@ -7,7 +7,7 @@ redirect_from:
 toc: true
 ---
 
-[Helm](https://helm.sh) is a package manager for Kubernetes (think apt or yum). It works by combining several manifests into a single package that is called [a chart](https://helm.sh/docs/developing_charts/). Helm also supports chart storage in remote or local Helm repositories that function like package registries such as Maven Central, Ruby Gems, NPM registry, etc.
+[Helm](https://helm.sh) is a package manager for Kubernetes (think apt or yum). It works by combining several manifests into a single package that is called [a chart](https://helm.sh/docs/developing_charts/). Helm also supports chart storage in remote or local Helm repositories that function like package registries such as Maven Central, Ruby Gems, npm registry, etc.
 
 Helm is currently the only solution that supports
 

--- a/_docs/new-helm/using-helm-in-codefresh-pipeline.md
+++ b/_docs/new-helm/using-helm-in-codefresh-pipeline.md
@@ -153,7 +153,7 @@ If a variable already contains a `_` (underscore) in its name, replace it with `
 
 All three modes of Helm usage are demonstrated in the following sections.
 
-You can also look at the [Github repository](https://github.com/codefresh-contrib/helm-sample-app) of [our Helm example]({{site.baseurl}}/docs/yaml-examples/examples/helm/) for full pipelines:
+You can also look at the [GitHub repository](https://github.com/codefresh-contrib/helm-sample-app) of [our Helm example]({{site.baseurl}}/docs/yaml-examples/examples/helm/) for full pipelines:
 
 * Pipeline YAML for deploying a chart(https://github.com/codefresh-contrib/helm-sample-app/blob/master/codefresh-do-not-store.yml)
 * Pipeline YAML for [both storing and deploying a chart](https://github.com/codefresh-contrib/helm-sample-app/blob/master/codefresh.yml)

--- a/_docs/testing/sonarqube-integration.md
+++ b/_docs/testing/sonarqube-integration.md
@@ -1,5 +1,5 @@
 ---
-title: "Sonarqube Scanning"
+title: "SonarQube Scanning"
 description: "How to trigger a SonarQube Analysis from Codefresh"
 group: testing
 redirect_from:

--- a/_docs/testing/test-reports.md
+++ b/_docs/testing/test-reports.md
@@ -34,9 +34,9 @@ max-width="70%"
 
 You can find more details in the [official Allure documentation](https://docs.qameta.io/allure/). Several popular test frameworks are supported such as:
 
-* Java/jUnit/testNG/cucumber
+* Java/JUnit/TestNG/Cucumber
 * Python/pytest
-* Javascript/Jasmine/Mocha
+* JavaScript/Jasmine/Mocha
 * Ruby/Rspec
 * Groovy/Spock
 * .NET/Nunit/mstest

--- a/_docs/troubleshooting/common-issues/cant-find-your-organization-repositories.md
+++ b/_docs/troubleshooting/common-issues/cant-find-your-organization-repositories.md
@@ -31,7 +31,7 @@ file="/images/415b5cf-2016-09-29_1530.png"
 url="/images/415b5cf-2016-09-29_1530.png"
 alt="2016-09-29_1530.png" 
 max-width="40%"
-caption="Github user menu (click image to enlarge)"
+caption="GitHub user menu (click image to enlarge)"
 %}
 
 ## 2. Navigate to your Authorized applications

--- a/_docs/troubleshooting/personal-git-deprecation.md
+++ b/_docs/troubleshooting/personal-git-deprecation.md
@@ -6,10 +6,10 @@ toc: true
 ---
 
 
-Codefresh supports several git providers (Github, Gitlab, Bitbucket etc.) via the [Git integration page]({{site.baseurl}}/docs/integrations/git-providers/) that allows you to define a connection to the respective git provider. Signing up with Codefresh typically requires you to use a Git provider for your basic information (and in the past, an automatic integration was created with the git provider that you used during initial sign-up).
+Codefresh supports several git providers (GitHub, GitLab, Bitbucket etc.) via the [Git integration page]({{site.baseurl}}/docs/integrations/git-providers/) that allows you to define a connection to the respective git provider. Signing up with Codefresh typically requires you to use a Git provider for your basic information (and in the past, an automatic integration was created with the git provider that you used during initial sign-up).
 
 
-At Codefresh, a single user [can belong to]({{site.baseurl}}/docs/enterprise/ent-account-mng/) multiple *Accounts* (think Github organizations). Typically a Codefresh user represents a single person while an *Account* represents a company or team.
+At Codefresh, a single user [can belong to]({{site.baseurl}}/docs/enterprise/ent-account-mng/) multiple *Accounts* (think GitHub organizations). Typically a Codefresh user represents a single person while an *Account* represents a company or team.
 
 Until July 2019 Codefresh allowed you to create a git integration either at the account level or at the user level. This has been problematic with several customer scenarios.
 

--- a/_docs/whats-new/whats-new.md
+++ b/_docs/whats-new/whats-new.md
@@ -24,7 +24,7 @@ Recent Codefresh updates:
 - New variable `CF_BRANCH_TAG_NORMALIZED_LOWER_CASE` - [documentation]({{site.baseurl}}/docs/codefresh-yaml/variables/#system-provided-variables)
 - Trigger a Kubernetes Deployment from a Dockerhub Push Event - [documentation]({{site.baseurl}}/docs/yaml-examples/examples/trigger-a-k8s-deployment-from-docker-registry/)
 - Uploading or Downloading from a Google Storage Bucket - [documentation]({{site.baseurl}}/docs/yaml-examples/examples/uploading-or-downloading-from-gs/)
-- Use Github actions no longer requires a Registry - [documentation]({{site.baseurl}}/docs/integrations/github-actions/#how-it-works)
+- Use GitHub Actions no longer requires a registry - [documentation]({{site.baseurl}}/docs/integrations/github-actions/#how-it-works)
 - Alternative debugging console - [documentation]({{site.baseurl}}/docs/configure-ci-cd-pipeline/debugging-pipelines/#using-the-alternative-debug-window)
 - User variable priority rules - [documentation]({{site.baseurl}}/docs/codefresh-yaml/variables/#user-provided-variables)
 - Secret Storage - [documentation]({{site.baseurl}}/docs/configure-ci-cd-pipeline/secrets-store/)
@@ -52,7 +52,7 @@ Recent Codefresh updates:
 ### February 2020
 
 - Beta Support for Helm 3 - [documentation]({{site.baseurl}}/docs/new-helm/helm3/)
-- Use Github actions as Codefresh pipeline steps - [documentation]({{site.baseurl}}/docs/integrations/github-actions/)
+- Use GitHub Actions as Codefresh pipeline steps - [documentation]({{site.baseurl}}/docs/integrations/github-actions/)
 - Publish a JAR to Artifactory/Nexus - [documentation]({{site.baseurl}}/docs/learn-by-example/java/publish-jar/)
 - New [dashboard](https://g.codefresh.io/builds) for builds - [documentation]({{site.baseurl}}/docs/configure-ci-cd-pipeline/monitoring-pipelines/)
   *  The git-event name is now included
@@ -125,7 +125,7 @@ Recent Codefresh updates:
 - Sidecar services in pipelines - [documentation]({{site.baseurl}}/docs/codefresh-yaml/service-containers/)
 - Personal Git providers are deprecated - [documentation]({{site.baseurl}}/docs/troubleshooting/personal-git-deprecation/)
 - Migrate from Jenkins to Codefresh - [documentation]({{site.baseurl}}/docs/integrations/jenkins-integration/#migrating-from-jenkins-to-codefresh)
-- MacOSX and iOS builds closed Alpha - [documentation]({{site.baseurl}}/docs/incubation/osx-ios-builds/)
+- macOS and iOS builds closed Alpha - [documentation]({{site.baseurl}}/docs/incubation/osx-ios-builds/)
 
 
 ### July 2019
@@ -329,7 +329,7 @@ Recent Codefresh updates:
  - We added integration with main self-hosted GIT providers to our PRO plan. You can now use Codefresh with your repositories from:
    - GitHub enterprise
    - Bitbucket Enterprise
-   - Gitlab enterprise
+   - GitLab enterprise
 
 
 

--- a/_docs/yaml-examples/examples/decryption-with-mozilla-sops.md
+++ b/_docs/yaml-examples/examples/decryption-with-mozilla-sops.md
@@ -14,7 +14,7 @@ toc: true
 
 ## The Example Java Application
 
-You can find the example project on [Github](https://github.com/codefresh-contrib/mozilla-sops-app).
+You can find the example project on [GitHub](https://github.com/codefresh-contrib/mozilla-sops-app).
 
 The example application retrieves the system variable "password," from the pipeline and uses it to authenticate to a Redis database, but you are free to use any type of database of your choosing.
 

--- a/_docs/yaml-examples/examples/deploy-to-heroku.md
+++ b/_docs/yaml-examples/examples/deploy-to-heroku.md
@@ -12,7 +12,7 @@ This tutorial will cover two examples, depending on your use case. If you are no
 
 ## The Example Django Application
 
-You can find the example project on [Github](https://github.com/codefresh-contrib/heroku-python-django-sample-app).
+You can find the example project on [GitHub](https://github.com/codefresh-contrib/heroku-python-django-sample-app).
 
 The repository contains a Django starter project with the following commands:
 

--- a/_docs/yaml-examples/examples/deploy-to-tomcat-via-scp.md
+++ b/_docs/yaml-examples/examples/deploy-to-tomcat-via-scp.md
@@ -13,7 +13,7 @@ toc: true
 
 ## The Example Java Application
 
-You can find the example project on [Github](https://github.com/codefresh-contrib/scp-war-app).
+You can find the example project on [GitHub](https://github.com/codefresh-contrib/scp-war-app).
 
 The example application is a simple Hello World Java application using the [Spark Java framework](http://sparkjava.com/):
 

--- a/_docs/yaml-examples/examples/deploy-with-kustomize.md
+++ b/_docs/yaml-examples/examples/deploy-with-kustomize.md
@@ -14,7 +14,7 @@ While it is good for simple scenarios, we suggest that you use Helm for managing
 
 ## The Example Application
 
-You can find the example project on [Github](https://github.com/codefresh-contrib/kustomize-sample-app).
+You can find the example project on [GitHub](https://github.com/codefresh-contrib/kustomize-sample-app).
 
 The sample application is a simple Spring Boot web app, that displays an environment variable, `MY_MYSQL_DB` on the page:
 

--- a/_docs/yaml-examples/examples/fan-in-fan-out.md
+++ b/_docs/yaml-examples/examples/fan-in-fan-out.md
@@ -31,7 +31,7 @@ You can achieve parallelism in your Codefresh pipelines by using the following:
 
 ## The Example Project
 
-You can find the example Spring boot application on [Github](https://github.com/codefresh-contrib/fan-out-fan-in-sample-app.git).  It is a simple Hello World application that has several different types of tests we will be using to run using Codefresh's parallel mode.
+You can find the example Spring boot application on [GitHub](https://github.com/codefresh-contrib/fan-out-fan-in-sample-app.git).  It is a simple Hello World application that has several different types of tests we will be using to run using Codefresh's parallel mode.
 
 ## Create the Pipeline
 

--- a/_docs/yaml-examples/examples/git-checkout.md
+++ b/_docs/yaml-examples/examples/git-checkout.md
@@ -17,7 +17,7 @@ caption="GIT integrations"
 max-width="70%"
 %}
 
-You can add new integration for any cloud provider or even [on-premise]({{site.baseurl}}/docs/enterprise/behind-the-firewall/) ones. By default you will also have a provider setup if you used one for Codefresh signup (Github, Gitlab or Bitbucket).
+You can add new integration for any cloud provider or even [on-premise]({{site.baseurl}}/docs/enterprise/behind-the-firewall/) ones. By default you will also have a provider setup if you used one for Codefresh signup (GitHub, GitLab or Bitbucket).
 
 For each Git Integration, make sure that you note down its name, as you will use in your pipeline inside a [git-clone]({{site.baseurl}}/docs/codefresh-yaml/steps/git-clone/) step.
 

--- a/_docs/yaml-examples/examples/launch-composition.md
+++ b/_docs/yaml-examples/examples/launch-composition.md
@@ -66,7 +66,7 @@ Be aware that the number of environments you can run is limited. When using the 
 {{site.data.callout.callout_info}}
 ##### Example
 
-Just head over to the example [**repository**](https://github.com/codefreshdemo/cf-example-launch-composition) in Github and follow the instructions there.
+Just head over to the example [**repository**](https://github.com/codefreshdemo/cf-example-launch-composition) in GitHub and follow the instructions there.
 {{site.data.callout.end}}
 
 Here is the end result:

--- a/_docs/yaml-examples/examples/pulumi.md
+++ b/_docs/yaml-examples/examples/pulumi.md
@@ -6,7 +6,7 @@ sub_group: examples
 toc: true
 ---
 
-[Pulumi](https://pulumi.io/) is a platform for *Infrastructure as Code*. It works like Terraform but allows you to use a proper programming language (Typescript, Python, Go) in order to describe your infrastructure (instead of a configuration language).
+[Pulumi](https://pulumi.io/) is a platform for *Infrastructure as Code*. It works like Terraform but allows you to use a proper programming language (TypeScript, Python, Go) in order to describe your infrastructure (instead of a configuration language).
 
 You can use Pulumi to deploy to Kubernetes or any other supported cloud platform. Because Pulumi itself is already offered [in a Docker container](https://hub.docker.com/r/pulumi/pulumi), it is very easy to run Pulumi in a Codefresh pipeline.
 
@@ -22,7 +22,7 @@ max-width="80%"
 
 ## The example Pulumi project
 
-You can see the example project at [https://github.com/codefresh-contrib/pulumi-sample-app](https://github.com/codefresh-contrib/pulumi-sample-app). The repository contains a simple Pulumi stack based on Kubernetes and Typescript.
+You can see the example project at [https://github.com/codefresh-contrib/pulumi-sample-app](https://github.com/codefresh-contrib/pulumi-sample-app). The repository contains a simple Pulumi stack based on Kubernetes and TypeScript.
 
 You can play with it locally after installing the `pulumi` executable.
 
@@ -86,7 +86,7 @@ steps:
 This pipeline does the following:
 
 1. Clones the source code with a [Git clone step]({{site.baseurl}}/docs/codefresh-yaml/steps/git-clone/)
-1. Runs `yarn install` to download dependencies. In this example we use Typescript, but Go and Python would work as well (or any other language supported by Pulumi)
+1. Runs `yarn install` to download dependencies. In this example we use TypeScript, but Go and Python would work as well (or any other language supported by Pulumi)
 1. Chooses the cluster that will be used for deployments (if you have more than one). Use your own cluster name as seen in the [Kubernetes dashboard]({{site.baseurl}}/docs/deploy-to-kubernetes/manage-kubernetes/) of Codefresh
 1. Runs `pulumi up` with the same target cluster
 

--- a/_docs/yaml-examples/examples/run-unit-tests.md
+++ b/_docs/yaml-examples/examples/run-unit-tests.md
@@ -8,7 +8,7 @@ redirect_from:
 toc: true
 ---
 
-As we have explained in the [Unit tests page]({{site.baseurl}}/docs/testing/unit-tests/) Codefresh supports several ways of running unit tests. The most usual scenarios are using an existing Dockerhub image (common with compiled languages such as Java and Go) or using the application image itself (common with languages such as Javascript/Python/Ruby/PHP).
+As we have explained in the [Unit tests page]({{site.baseurl}}/docs/testing/unit-tests/) Codefresh supports several ways of running unit tests. The most usual scenarios are using an existing Docker Hub image (common with compiled languages such as Java and Go) or using the application image itself (common with languages such as JavaScript/Python/Ruby/PHP).
 
 In this example we will see both ways using two different applications in a single pipeline.
 

--- a/_docs/yaml-examples/examples/secure-a-docker-container-using-http-basic-auth.md
+++ b/_docs/yaml-examples/examples/secure-a-docker-container-using-http-basic-auth.md
@@ -82,5 +82,5 @@ max-width="40%"
 {{site.data.callout.callout_info}}
 ##### Example 
 
-Just head over to the example [__repository__](https://github.com/codefreshdemo/cf-example-basic-auth-container){:target="_blank"} in Github and follow the instructions there.
+Just head over to the example [__repository__](https://github.com/codefreshdemo/cf-example-basic-auth-container){:target="_blank"} in GitHub and follow the instructions there.
 {{site.data.callout.end}}

--- a/_docs/yaml-examples/examples/shared-volumes-between-builds.md
+++ b/_docs/yaml-examples/examples/shared-volumes-between-builds.md
@@ -51,7 +51,7 @@ More information about caching build dependencies you can find [in this blog pos
 
 ### Example Source code
 
-Just head over to the example [**repository**](https://github.com/codefreshdemo/cf-example-shared-volumes-between-builds){:target="_blank"} in Github and follow the instructions there. 
+Just head over to the example [**repository**](https://github.com/codefreshdemo/cf-example-shared-volumes-between-builds){:target="_blank"} in GitHub and follow the instructions there. 
 
 
 >The way the volume is shared between builds is that upon build completion we create an image of the volume state to be used in the next builds. If you run 2 builds in parallel from the same pipeline and at the same time, each will use the same last volume image, but it’ll run separately on both. The volume image you’ll get upon completion is the state of the build that finished last. 

--- a/_docs/yaml-examples/examples/spring-boot-kafka-zookeeper.md
+++ b/_docs/yaml-examples/examples/spring-boot-kafka-zookeeper.md
@@ -13,7 +13,7 @@ This project uses `Java, Spring Boot, Kafka, Zookeeper` to show you how to integ
 {{site.data.callout.callout_info}}
 ##### Example 
 
-Just head over to the example [__repository__](https://github.com/codefreshdemo/example-springboot-kafka){:target="_blank"} in Github and follow the instructions there.
+Just head over to the example [__repository__](https://github.com/codefreshdemo/example-springboot-kafka){:target="_blank"} in GitHub and follow the instructions there.
 {{site.data.callout.end}}
 
 ## Zookeeper Docker image

--- a/_docs/yaml-examples/examples/transferring-php-ftp.md
+++ b/_docs/yaml-examples/examples/transferring-php-ftp.md
@@ -17,7 +17,7 @@ redirect_from:
 
 ## The Example Php Project
 
-The example project can be found on [Github](https://github.com/codefresh-contrib/ftp-php-app).  The application is a simple Php application that displays an example timer.
+The example project can be found on [GitHub](https://github.com/codefresh-contrib/ftp-php-app).  The application is a simple Php application that displays an example timer.
 
 {% include image.html 
 lightbox="true" 

--- a/_docs/yaml-examples/examples/uploading-or-downloading-from-gs.md
+++ b/_docs/yaml-examples/examples/uploading-or-downloading-from-gs.md
@@ -14,7 +14,7 @@ toc: true
 
 ## The Example Project
 
-The example project can be found on [Github](https://github.com/codefresh-contrib/gcloud-storage-sample-app.git).  The application is a simple Scala Hello World application contained in a jar, with a dependency on a scala-library jar which we will download from the bucket and package into a Docker image.
+The example project can be found on [GitHub](https://github.com/codefresh-contrib/gcloud-storage-sample-app.git).  The application is a simple Scala Hello World application contained in a jar, with a dependency on a scala-library jar which we will download from the bucket and package into a Docker image.
 
 Our project will contain two pipelines, one for uploading the dependency jar to our bucket, and the other for downloading the jar from the bucket.
 

--- a/_docs/yaml-examples/examples/vault-secrets-in-the-pipeline.md
+++ b/_docs/yaml-examples/examples/vault-secrets-in-the-pipeline.md
@@ -16,7 +16,7 @@ Codefresh offers a Vault plugin you may use from the [Step Marketplace](https://
 
 ## The Example Java Application
 
-You can find the example project on [Github](https://github.com/codefresh-contrib/vault-sample-app).
+You can find the example project on [GitHub](https://github.com/codefresh-contrib/vault-sample-app).
 
 The example application retrieves the system variable "password," from the pipeline and uses it to authenticate to a Redis database, but you are free to use any type of database of your choosing.
 

--- a/_pages/how-to-use.md
+++ b/_pages/how-to-use.md
@@ -17,7 +17,7 @@ You have a few option how to specify/provide callout message
 {{site.data.callout.callout_info}}
 ##### Example 
 
-Just head over to the example [__repository__](https://github.com/codefreshdemo/example-springboot-kafka){:target="_blank"} in Github and follow the instructions there.
+Just head over to the example [__repository__](https://github.com/codefreshdemo/example-springboot-kafka){:target="_blank"} in GitHub and follow the instructions there.
 {{site.data.callout.end}}
 
 {% endraw %}
@@ -28,7 +28,7 @@ Just head over to the example [__repository__](https://github.com/codefreshdemo/
 {{site.data.callout.callout_info}}
 ##### Example
 
-Just head over to the example [__repository__](https://github.com/codefreshdemo/example-springboot-kafka){:target="_blank"} in Github and follow the instructions there.
+Just head over to the example [__repository__](https://github.com/codefreshdemo/example-springboot-kafka){:target="_blank"} in GitHub and follow the instructions there.
 {{site.data.callout.end}}
 
 #### Available styles:


### PR DESCRIPTION
A bunch of typo/capitalization fixes, e.g.:

- `Github` -> `GitHub`
- `Gitlab` -> `GitLab`
- `Javascript` -> `JavaScript`
- `NPM` -> `npm`

No content changes in this PR.