### PR TITLE
Add link to available Helm versions (image tags)

### DIFF
--- a/_docs/new-helm/using-helm-in-codefresh-pipeline.md
+++ b/_docs/new-helm/using-helm-in-codefresh-pipeline.md
@@ -243,7 +243,7 @@ cmd_ps|optional|Command Postscript - this will be appended as is to the generate
 commands|optional|commands to execute in plugin after auth action
 custom_value_files|optional|values file to provide to Helm as --values or -f
 custom_values|optional|values to provide to Helm as --set
-helm_version|optional|version of cfstep-helm image
+helm_version|optional|version of [cfstep-helm image](https://hub.docker.com/r/codefresh/cfstep-helm/tags)
 kube_context|required for install|Kubernetes context to use. The name of the cluster as [configured in Codefresh]({{site.baseurl}}/docs/deploy-to-kubernetes/add-kubernetes-cluster/)
 namespace|optional|Target Kubernetes namespace to deploy to
 release_name|required for install|Helm release name. If the release exists, it will be upgraded


### PR DESCRIPTION
It took me a bit of digging to figure out which versions of Helm are supported, so I thought it might be helpful to add a direct link to the tags page here.

For reference, I was using Helm 3.3.4 locally so I tried adding that in my step and it didn't work because there's not an image for it. The image wasn't that difficult to find, but this would have saved me a couple minutes. Maybe this change will save someone else time too :)