### PR TITLE
Add note about Sonarqube language specific settings

### DIFF
--- a/_docs/testing/sonarqube-integration.md
+++ b/_docs/testing/sonarqube-integration.md
@@ -59,6 +59,12 @@ sonar.projectName=your project's name
 
 The file is needed to run the SonarQube plugin.
 
+<div class="bd-callout bd-callout-info" markdown="1">
+##### Language-specific Settings
+
+Please note that projects using some languages may require additional configuration. For information on what may be needed for your language, refer to the appropriate language page in the [Sonarqube documentation](https://docs.sonarqube.org/latest/analysis/languages/overview/)
+</div>
+
 ## Running an analysis from the Codefresh Plugin
 
 If you are using the predefined Codefresh pipeline you just need to look-up SonarQube under `STEPS` and you will find the custom plugin.


### PR DESCRIPTION
Adding a note about language specific required fields in the `sonarqube-project.properties` file. This came up while trying to help an enterprise customer get their Java application running, and it turns out there is an additional required setting that wasn't applied. This is likely the case for some other languages as well, so I added a generic note.

Please preview this locally before merging, I had issues with dependencies and wasn't able to make sure my formatting was okay.