### PR TITLE
Adding org admin permission justification

### DIFF
--- a/_docs/integrations/git-providers.md
+++ b/_docs/integrations/git-providers.md
@@ -104,6 +104,8 @@ The minimum permissions for the token are:
 - `admin:repo_hook.*`
 - `admin:org.*`
 
+> The admin permission for the org is required to allow the addition of webhhoks on org projects.
+
 {% include image.html 
 lightbox="true" 
 file="/images/integrations/git/github-token.png" 


### PR DESCRIPTION
Customer asked why we needed full admin permission at the org level so adding a justification may help alleviate concerns
Recorded in CR-3727