### PR TITLE
Update service-containers.md

### DIFF
--- a/_docs/codefresh-yaml/service-containers.md
+++ b/_docs/codefresh-yaml/service-containers.md
@@ -11,6 +11,8 @@ Sometimes you wish to run sidecar containers in a pipeline that offer additional
 
 Codefresh includes a handy mechanism (based on Docker compose) that can help you run sidecar containers along your main pipeline. Here is a very simple example.
 
+>Service Containers are base on Docker Compose. This document does not have the complete list of available options available. Please refer to Docker Compose versions [2](https://docs.docker.com/compose/compose-file/compose-file-v2/) and [3](https://docs.docker.com/compose/compose-file/), but not point releases such as 2.1.
+
  `codefresh.yml`
 {% highlight yaml %}
 {% raw %}


### PR DESCRIPTION
Since Service Containers is base on Docker Compose.  Added a note to make this stand out more, and that this doc is not a complete list of options available.  ZD 8142 for more details.