### PR TITLE
Updated documentation for deploy with kustomize

### DIFF
--- a/_docs/yaml-examples/examples/deploy-with-kustomize.md
+++ b/_docs/yaml-examples/examples/deploy-with-kustomize.md
@@ -96,7 +96,7 @@ caption="Codefresh UI Pipeline View"
 max-width="100%" 
 %}
 
-You should be able to copy and paste this YAML in the in-line pipeline editor of the Codefresh UI. However, make sure to replace the context with your own that you integrated with Codefresh. It will automatically clone the project for you and deploy.
+You should be able to copy and paste this YAML in the in-line pipeline editor of the Codefresh UI. However, make sure to replace cluster context for the kubectl command under the arguments section with your own that you integrated with Codefresh. It will automatically clone the project for you and deploy.
 
 `staging-codefresh.yml`
 {% highlight yaml %}
@@ -157,7 +157,7 @@ caption="Codefresh UI Pipeline View"
 max-width="100%" 
 %}
 
-You should be able to copy and paste this YAML in the in-line editor of the Codefresh UI and remember to replace the context again with your own. Click Save and Run and it will automatically clone the project for you.
+You should be able to copy and paste this YAML in the in-line editor of the Codefresh UI and remember to replace cluster context for the kubectl command again with your own. Click Save and Run and it will automatically clone the project for you.
 
 `prod-codefresh.yml`
 {% highlight yaml %}


### PR DESCRIPTION
Added specific instructions for the reader to replace the context with their own that they integrated with Codefresh, otherwise if instructed just to copy/paste as currently advised the reader will get an error.