### PR TITLE
feat: Adding requested buttons to the primary nav.

### DIFF
--- a/_includes/docs-navbar.html
+++ b/_includes/docs-navbar.html
@@ -1,6 +1,6 @@
 <header class="bd-navbar py-2 py-md-0">
   <div class="container-fluid navbar navbar-dark navbar-expand flex-column flex-md-row py-0">
-    <a class="navbar-brand mr-0 mr-md-2" href="{{ site.baseurl }}/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Home');" aria-label="Codefresh">
+    <a class="navbar-brand mx-0 mx-md-2" href="{{ site.baseurl }}/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Home');" aria-label="Codefresh">
       {%- include icons/codefresh-icon.svg width="50" height="auto" class="align-middle" -%}
       <span class="badge cf-badge cf-badge-doc align-middle ml-1">Docs</span>
     </a>
@@ -17,8 +17,8 @@
     </form>
     {% endif %}
 
-    <div class="navbar-nav-scroll order-1 order-md-1 mr-md-auto">
-    <ul class="navbar-nav flex-row ml-md-auto">
+    <div class="navbar-nav-scroll order-1 order-md-1 mx-md-auto">
+    <ul class="navbar-nav flex-row mx-md-auto">
 
       <li class="nav-item">
         <a class="nav-link" href="{{ site.link_main }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Product');">Product</a>
@@ -88,5 +88,6 @@
       {% endcomment %}
     </ul>
     </div>
+    <a class="btn btn-primary order-2 order-md-2" href="https://codefresh.io/csdp-docs/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open CSDP Docs');" style="background: #11b5a4; border-color: #11b5a4; margin-top: 11px;" >View CSDP Docs</a>
   </div>
 </header>

--- a/_includes/docs-navbar.html
+++ b/_includes/docs-navbar.html
@@ -88,6 +88,6 @@
       {% endcomment %}
     </ul>
     </div>
-    <a class="btn btn-primary order-2 order-md-2" href="https://codefresh.io/csdp-docs/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open CSDP Docs');" style="background: #11b5a4; border-color: #11b5a4; margin-top: 11px;" >View CSDP Docs</a>
+    <a class="btn btn-primary order-2 order-md-2" href="https://codefresh.io/csdp-docs/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open CSDP Docs');" style="background: #11b5a4; border-color: #11b5a4;" >View CSDP Docs</a>
   </div>
 </header>


### PR DESCRIPTION
Signed-off-by: brandonLyonCf <brandon.lyon@codefresh.io>

Per request from Noga, adding a button to the primary navigation that links to the other version of the docs site.

Note that the version of SASS used in the docs site is 4.7, which appears to require node version 8 (the current version is 17). I don't think I can compile CSS because it doesn't support recent versions of Mac OS. I tried using the docker method but that doesn't appear to compile SASS/CSS.

Long term we'll want to update the package versions. For now, I can try to style the requested v1/v2 navigation buttons using inline `<style>` tags.