### PR TITLE
fail_fast is not supported in typed-step

### DIFF
--- a/_docs/codefresh-yaml/steps.md
+++ b/_docs/codefresh-yaml/steps.md
@@ -9,7 +9,7 @@ toc: true
 
 Codefresh [pipelines]({{site.baseurl}}/docs/configure-ci-cd-pipeline/introduction-to-codefresh-pipelines/) are composed of a series of steps. 
 
-You can create your own pipelines by writing a  [codefresh.yml]({{site.baseurl}}/docs/codefresh-yaml/what-is-the-codefresh-yaml/) file that describes your pipeline. This file can then be version controlled on its own (pipeline as code).
+You can create your own pipelines by writing a [codefresh.yml]({{site.baseurl}}/docs/codefresh-yaml/what-is-the-codefresh-yaml/) file that describes your pipeline. This file can then be version controlled on its own (pipeline as code).
 
 {% include 
 image.html 
@@ -1206,7 +1206,7 @@ This was a contrived example to demonstrate how you can use templates in the Cod
 
 [Parallel steps]({{site.baseurl}}/docs/codefresh-yaml/advanced-workflows/) are not supported inside custom steps.
   
-The [fail_fast field]({{site.baseurl}}/docs/codefresh-yaml/what-is-the-codefresh-yaml/#execution-flow) does not work inside custome step, you have to use `failFast` field instead.
+Within a custom step, the [fail_fast field]({{site.baseurl}}/docs/codefresh-yaml/what-is-the-codefresh-yaml/#execution-flow) does not work. Use  the `failFast` field instead.
 
 Custom steps are not compatible with [service containers]({{site.baseurl}}/docs/codefresh-yaml/service-containers/). 
 More specifically:

--- a/_docs/codefresh-yaml/steps.md
+++ b/_docs/codefresh-yaml/steps.md
@@ -1205,6 +1205,8 @@ This was a contrived example to demonstrate how you can use templates in the Cod
 ### Limitations of custom plugins
 
 [Parallel steps]({{site.baseurl}}/docs/codefresh-yaml/advanced-workflows/) are not supported inside custom steps.
+  
+The [fail_fast field]({{site.baseurl}}/docs/codefresh-yaml/what-is-the-codefresh-yaml/#execution-flow) does not work inside custome step, you have to use `failFast` field instead.
 
 Custom steps are not compatible with [service containers]({{site.baseurl}}/docs/codefresh-yaml/service-containers/). 
 More specifically:


### PR DESCRIPTION
The property does not work but can be replaced by failFast instead
See https://codefresh-io.atlassian.net/browse/CR-11180