### PR TITLE
update secure way for 1.24

### DIFF
--- a/_docs/deploy-to-kubernetes/add-kubernetes-cluster.md
+++ b/_docs/deploy-to-kubernetes/add-kubernetes-cluster.md
@@ -353,8 +353,9 @@ echo $(kubectl get secret -n kube-system -o go-template='{{index .data "token" }
 
 #### The proper/secure way for Kubernetes Cluster 1.24+
 
-For production environments you should create a service account and/or role for Codefresh access.
-The minimum permissions Codefresh needs to work with the cluster are the following:
+For production environments, create a service account and/or role for Codefresh access.  
+
+Codefresh needs these minimum permissions to work with the cluster:
 
 `codefresh-role.yml`
 {% highlight yaml %}
@@ -370,7 +371,7 @@ rules:
 {% endraw %}
 {% endhighlight %}
 
-Note that these permissions will only allow Codefresh to read the cluster resources and populate the respective dashboards. You need to give more privileges for actual deployments. For more information see the [Kubernetes RBAC documentation page](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
+Note that these permissions will only allow Codefresh to read the cluster resources and populate the respective dashboards. You need to give more privileges for actual deployments. For more information see the [Kubernetes RBAC documentation page](https://kubernetes.io/docs/reference/access-authn-authz/rbac/){:target="\_blank"}.
 
 Here is an example with role + service account + binding.
 
@@ -417,8 +418,9 @@ metadata:
 {% endraw %}
 {% endhighlight %}
 
-Select the appropriate cluster if you have more than one:
+<br />
 
+1. Select the appropriate cluster if you have more than one:
 `Choose cluster`
 {% highlight shell %}
 {% raw %}
@@ -426,7 +428,7 @@ kubectl config use-context <my-cluster-name>
 {% endraw %}
 {% endhighlight %}
 
-Create the Codefresh user/role:
+1. Create the Codefresh user/role:
 
 `Apply Codefresh access rules`
 {% highlight shell %}
@@ -435,7 +437,7 @@ kubectl apply -f codefresh-role-sa-bind.yml
 {% endraw %}
 {% endhighlight %}
 
-Finally run the following commands and copy-paste the result to each Codefresh field in the UI:
+1. Finally run the following commands, and copy-paste the results to the respective Codefresh field in the UI:
 
 `Host IP`
 {% highlight shell %}

--- a/_docs/deploy-to-kubernetes/add-kubernetes-cluster.md
+++ b/_docs/deploy-to-kubernetes/add-kubernetes-cluster.md
@@ -351,6 +351,113 @@ echo $(kubectl get secret -n kube-system -o go-template='{{index .data "token" }
 {% endraw %}
 {% endhighlight %}
 
+#### The proper/secure way for Kubernetes Cluster 1.24+
+
+For production environments you should create a service account and/or role for Codefresh access.
+The minimum permissions Codefresh needs to work with the cluster are the following:
+
+`codefresh-role.yml`
+{% highlight yaml %}
+{% raw %}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: codefresh-role
+rules:
+  - apiGroups: [“”]
+    resources: [“*”]
+    verbs: [“list”, “watch”, “get”] 
+{% endraw %}
+{% endhighlight %}
+
+Note that these permissions will only allow Codefresh to read the cluster resources and populate the respective dashboards. You need to give more privileges for actual deployments. For more information see the [Kubernetes RBAC documentation page](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
+
+Here is an example with role + service account + binding.
+
+`codefresh-role-sa-bind.yml`
+{% highlight yaml %}
+{% raw %}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: codefresh-role
+rules:
+  - apiGroups: [ “*”]
+    resources: [“*”]
+    verbs: [“get”, “list”, “watch”, “create”, “update”, “patch”, “delete”]
+—
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: codefresh-user
+  namespace: kube-system
+—
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: codefresh-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: codefresh-role
+subjects:
+- kind: ServiceAccount
+  name: codefresh-user
+  namespace: kube-system
+—
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: codefresh-user-token
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: “codefresh-user” 
+    
+{% endraw %}
+{% endhighlight %}
+
+Select the appropriate cluster if you have more than one:
+
+`Choose cluster`
+{% highlight shell %}
+{% raw %}
+kubectl config use-context <my-cluster-name>
+{% endraw %}
+{% endhighlight %}
+
+Create the Codefresh user/role:
+
+`Apply Codefresh access rules`
+{% highlight shell %}
+{% raw %}
+kubectl apply -f codefresh-role-sa-bind.yml
+{% endraw %}
+{% endhighlight %}
+
+Finally run the following commands and copy-paste the result to each Codefresh field in the UI:
+
+`Host IP`
+{% highlight shell %}
+{% raw %}
+export CURRENT_CONTEXT=$(kubectl config current-context) && export CURRENT_CLUSTER=$(kubectl config view -o go-template=“{{\$curr_context := \”$CURRENT_CONTEXT\” }}{{range .contexts}}{{if eq .name \$curr_context}}{{.context.cluster}}{{end}}{{end}}”) && echo $(kubectl config view -o go-template=“{{\$cluster_context := \”$CURRENT_CLUSTER\”}}{{range .clusters}}{{if eq .name \$cluster_context}}{{.cluster.server}}{{end}}{{end}}”)
+{% endraw %}
+{% endhighlight %}
+
+`Certificate`
+{% highlight shell %}
+{% raw %}
+echo $(kubectl get secret -n kube-system -o go-template=‘{{index .data “ca.crt” }}’ codefresh-user-token)
+{% endraw %}
+{% endhighlight %}
+
+`Token`
+{% highlight shell %}
+{% raw %}
+echo $(kubectl get secret -n kube-system -o go-template=‘{{index .data “token” }}’ codefresh-user-token)
+{% endraw %}
+{% endhighlight %}
+
 ### Restrict Codefresh access to a specific namespace
 
 In most cases, you want to allow Codefresh to access all namespaces inside the cluster. This is the most convenient option as it will make


### PR DESCRIPTION
Kubernetes does a different way to handle service account tokens generation.   Added the way to do it for cluster 1.24+

ref: https://blog.nuvotex.de/service-accounts-in-kubernetes-1-24/