### PR TITLE
docs(service-containers): describe `shared_host_network: true` pitfalls

### DIFF
--- a/_docs/codefresh-yaml/service-containers.md
+++ b/_docs/codefresh-yaml/service-containers.md
@@ -544,8 +544,14 @@ steps:
 {% endraw %}      
 {% endhighlight %}
 
-Note: we do recommend you only use this option as a last resort. You should not hardcode "localhost" as a requirement in your services as
-it adds extra constraints with integration tests (and especially with dynamic test environments).
+> 💡 Note
+>
+> We do recommend you only use this option as a last resort. You should not hardcode "localhost" as a requirement in your services as it adds extra constraints with integration tests (and especially with dynamic test environments).
+
+> ⚠️ Warning
+>
+> If `shared_host_network: true`, services will no longer be available by name.
+> This means that you cannot mix access by name and localhost within one service group, you have to choose one and use `shared_host_network` attribute accordingly.
 
 
 ## Limitations 
@@ -561,11 +567,3 @@ Service containers are not compatible with [custom pipeline steps]({{site.baseur
 * [Integration tests]({{site.baseurl}}/docs/testing/integration-tests/)
 * [Integration test with database]({{site.baseurl}}/docs/yaml-examples/examples/integration-tests-with-database/)
 * [Creating Compositions]({{site.baseurl}}/docs/on-demand-test-environment/create-composition/)
-
-
-
-
-
-
-
-

--- a/_docs/getting-started/faq.md
+++ b/_docs/getting-started/faq.md
@@ -147,7 +147,7 @@ The following browser versions are **NOT** supported:
 ## Enterprise support
 
 **Q. Does Codefresh support SSO?**    
-A. Yes, we support several [popular SSO providers]({{site.baseurl}}/docs/enterprise/single-sign-on/).
+A. Yes, we support several [popular SSO providers]({{site.baseurl}}/docs/single-sign-on/sso-overview/).
 
 **Q. Does Codefresh support access control?**    
 A. Yes, we support both UI and ABAC on [pipelines, projects and clusters]({{site.baseurl}}/docs/enterprise/access-control/).
@@ -167,4 +167,3 @@ A. Yes, we do.
 * [How Codefresh pipelines work]({{site.baseurl}}/docs/configure-ci-cd-pipeline/introduction-to-codefresh-pipelines/)
 * [Kubernetes Deployment tutorial]({{site.baseurl}}/docs/getting-started/deployment-to-kubernetes-quick-start-guide/)
 * [Helm Deployment Tutorial tutorial]({{site.baseurl}}/docs/getting-started/helm-quick-start-guide/)
-


### PR DESCRIPTION
This adds a warning that accessing service containers by name is impossible when `shared_host_network: true`.

Also, a broken link in “Getting Started → FAQ” is fixed.