### PR TITLE
Fix GitHub App manual creation

### DIFF
--- a/_docs/integrations/git-providers.md
+++ b/_docs/integrations/git-providers.md
@@ -192,7 +192,7 @@ An alternative way to authenticate with Github is via the App mechanism.
 1. From the **Add Git Provider** dropdown, select **Github App**.  
   For the required fields use: 
   * **App ID**, which you noted down in _step 4.1_.
-  * **Private key**, which is the content of the file your created in _step 4.2_, converted to base64.
+  * **Private key**, which is the content of the file you created in _step 4.2_, converted to base64.
   * **Installation ID** which you noted down in _step 6_.
 1. To verify your integration, click **Test connection**.
 1. To apply your changes, click **Save**.  

--- a/_docs/integrations/git-providers.md
+++ b/_docs/integrations/git-providers.md
@@ -148,7 +148,11 @@ An alternative way to authenticate with Github is via the App mechanism.
 
 ### Codefresh Github App
 
-> The Codefresh App has READ permissions to issues, metadata, and pull requests, and READ and WRITE permissions to code, commit statuses, and repository hooks. If you need additional permission for your integration, use the Manual Creation steps.
+> The Codefresh App has:  
+> * READ permissions to issues, metadata, and pull requests 
+> * READ and WRITE permissions to code, commit statuses, and repository hooks
+
+> If you need additional permission for your integration, use the Manual Creation steps.
 
 1. In the Codefresh UI, follow the steps to [add a new Git provider](#adding-more-git-providers-to-your-codefresh-account). 
 1. From the list of Git providers, select **Codefresh Github App**.
@@ -160,39 +164,40 @@ An alternative way to authenticate with Github is via the App mechanism.
 
 ### Manual creation
 
-1. Log in your GitHub account and visit [https://github.com/settings/apps](https://github.com/settings/apps){:target="\_blank"}. 
+1. Log in to your GitHub account and visit [https://github.com/settings/apps](https://github.com/settings/apps){:target="\_blank"}. 
 1. Click **New GitHub App**.
 1. Do the following in the New GitHub App screen:
-     1. Give an arbitrary name to your app (e.g. codefresh-integration)
-     1. Fill *Homepage URL* with `http://www.codefresh.io`
-     1. Uncheck the *Active* checkbox under the Webhook section
-     1. In the *Repository permissions* section give the minimum of
-       * **Contents** - read
-       * **Issues** - read
-       * **Metadata** - read
-       * **Pull requests** - read
-       * **Webhooks** - read, write
-       * **Commit statuses** - read, write
-       * **Email addresses** - read 
-     1. Click the *Create GitHub app* button.
+    1. Enter an arbitrary name for your app in **GitHub App name**. For example, `codefresh-integration`.
+    1. In the **Homepage URL**, enter `http://www.codefresh.io`.
+    1. In the Webhook section, clear the **Active** checkbox.
+    1. In the **Repository Permissions** section, assign the following permissions:  
+        * **Contents**: Read
+        * **Issues**: Read
+        * **Metadata**: Read
+        * **Pull requests**: Read
+        * **Webhooks**: Read, write
+        * **Commit statuses**: Read, write
+    1. In the **Account Permissions** section, assign the Read permission to **Email addresses**.
+    1. Click the **Create GitHub app**.
 
 1. In the next screen, do the following:
      1. Note down the **App ID** number under the About section.
-     1. Click **Generate a private key**,  and save the file locally.
-1. Click the **Install App** item from the left sidebar menu, and then click **Install** next to your codefresh app.
+     1. Click **Generate a private key**, and save the file locally.
+1. From the sidebar, click **Install App**, and then click **Install** next to your Codefresh app.
 1. Accept the permissions, and in the next screen, define the repositories that you need Codefresh to access.  
   From the URL of the browser, note the ending number which is your installation ID.  
-  For example if the URL is `https://github.com/settings/installations/10042353` then your installation number is `10042353`.
-1. In the Codefresh UI, go to  [Pipeline Integrations > Git](https://g.codefresh.io/account-admin/account-conf/integration/git){:target="\_blank"}. 
+  For example if the URL is `https://github.com/settings/installations/10042353`, then your installation number is `10042353`.
+1. In the Codefresh UI, in the toolbar, click the **Settings** icon.
+1. From the sidebar, select [**Pipeline Integrations** > Git**](https://g.codefresh.io/account-admin/account-conf/integration/git){:target="\_blank"}, and then click **Configure**. 
 1. From the **Add Git Provider** dropdown, select **Github App**.  
   For the required fields use: 
-  * **Installation ID** which you noted down in _step 5_.
-  * **App ID**, which you noted down in _step 4_.
-  * **Private key**, which is the content of the file your created in step 4, converted to base64.
+  * **App ID**, which you noted down in _step 4.1_.
+  * **Private key**, which is the content of the file your created in _step 4.1_, converted to base64.
+  * **Installation ID** which you noted down in _step 6_.
 1. To verify your integration, click **Test connection**.
 1. To apply your changes, click **Save**.  
 
->If enabled in your account you can setup [Pipeline definition restrictions]({{site.baseurl}}/docs/administration/account-user-management/access-control/#pipeline-definition-restrictions) by expanding the *YAML Options* segment.
+>If enabled in your account you can set up [Pipeline definition restrictions]({{site.baseurl}}/docs/administration/account-user-management/access-control/#pipeline-definition-restrictions) by expanding the *YAML Options* segment.
 
 ## GitLab
 

--- a/_docs/integrations/git-providers.md
+++ b/_docs/integrations/git-providers.md
@@ -188,11 +188,11 @@ An alternative way to authenticate with Github is via the App mechanism.
   From the URL of the browser, note the ending number which is your installation ID.  
   For example if the URL is `https://github.com/settings/installations/10042353`, then your installation number is `10042353`.
 1. In the Codefresh UI, in the toolbar, click the **Settings** icon.
-1. From the sidebar, select [**Pipeline Integrations** > Git**](https://g.codefresh.io/account-admin/account-conf/integration/git){:target="\_blank"}, and then click **Configure**. 
+1. From the sidebar, select **Pipeline Integrations > Git**, and then click **Configure**. 
 1. From the **Add Git Provider** dropdown, select **Github App**.  
   For the required fields use: 
   * **App ID**, which you noted down in _step 4.1_.
-  * **Private key**, which is the content of the file your created in _step 4.1_, converted to base64.
+  * **Private key**, which is the content of the file your created in _step 4.2_, converted to base64.
   * **Installation ID** which you noted down in _step 6_.
 1. To verify your integration, click **Test connection**.
 1. To apply your changes, click **Save**.  


### PR DESCRIPTION
Moved Email addresses permission to Account Permissions section instead of Repo permissions; fixed incorrect formatting