### PR TITLE
docs(kb): update outdated links to ZD articles

### DIFF
--- a/_docs/administration/account-user-management/add-users.md
+++ b/_docs/administration/account-user-management/add-users.md
@@ -113,12 +113,10 @@ As an administrator, you can optionally define session timeouts to automatically
 
 ## Troubleshoot add users
 
-* [User is prompted to enter an organization name](https://support.codefresh.io/hc/en-us/articles/360020177959-User-is-prompted-to-enter-an-organization-name){:target="\_blank"}
-* [Account invitation not permitting login](https://support.codefresh.io/hc/en-us/articles/360015251000-Account-invitation-not-permitting-login){:target="\_blank"}
+* [Account invitation not permitting login]({{site.baseurl}}/docs/kb/articles/account-invite-not-permitting-login){:target="\_blank"}
 <!--this is already mentioned as inline refs; add other topics-->
 
 ## Related articles
 [Access control]({{site.baseurl}}/docs/administration/account-user-management/access-control/)  
 [Single Sign on]({{site.baseurl}}/docs/single-sign-on/single-sign-on/)  
 [Setting up OAuth authentication for Git providers]({{site.baseurl}}/docs/administration/account-user-management/oauth-setup)  
-

--- a/_docs/installation/codefresh-runner.md
+++ b/_docs/installation/codefresh-runner.md
@@ -451,7 +451,7 @@ GKE volume configuration includes:
 
 Configure the Codefresh Runner to use local SSDs for your pipeline volumes:
 
-[How-to: Configuring an existing Runtime Environment with Local SSDs (GKE only)](https://support.codefresh.io/hc/en-us/articles/360016652920-How-to-Configuring-an-existing-Runtime-Environment-with-Local-SSDs-GKE-only-){:target="\_blank"}
+[How-to: Configuring an existing Runtime Environment with Local SSDs (GKE only)]({{site.baseurl}}/docs/kb/articles/config-re-gke-ssd){:target="\_blank"}
 
 <br />
 
@@ -469,7 +469,7 @@ There are three options to provide cloud credentials:
 Notice that builds run in a single Availability Zone (AZ), so you must specify Availability Zone parameters.
 
 **Configuration**  
-[How-to: Configuring an existing Runtime Environment with GCE disks](https://support.codefresh.io/hc/en-us/articles/360016652900-How-to-Configuring-an-existing-Runtime-Environment-with-GCE-disks){:target="\_blank"}
+[How-to: Configuring an existing Runtime Environment with GCE disks]({{site.baseurl}}/docs/kb/articles/config-re-gke-gce-disk){:target="\_blank"}
 
 <br />
 
@@ -2221,7 +2221,7 @@ codefresh runner delete --help
 
 ## Troubleshooting
 
-For troubleshooting refer to the [Knowledge Base](https://support.codefresh.io/hc/en-us/sections/4416999487762-Hybrid-Runner){:target="\_blank"}
+For troubleshooting refer to the [Knowledge Base]({{site.baseurl}}/docs/kb/troubleshooting/#runtimes){:target="\_blank"}
 
 ## Related articles
 [Codefresh installation options]({{site.baseurl}}/docs/installation/installation-options/)  

--- a/_docs/terms-and-privacy-policy/sla.md
+++ b/_docs/terms-and-privacy-policy/sla.md
@@ -72,7 +72,7 @@ issue as defined below and will use commercially reasonable efforts to respond a
 | Normal        | Errors that cause previously-working non-critical features to malfunction. |
 | Low | General questions, How-To’s, best practices questions, and feature requests.|
 
-[Severity Examples](https://support.codefresh.io/hc/en-us/articles/360018951039-Codefresh-SLA-definitions)
+[Severity Examples]({{site.baseurl}}/docs/terms-and-privacy-policy/codefresh-sla-definitions)
 
 **3.3. Support Channels**. 
 
@@ -96,4 +96,3 @@ issue as defined below and will use commercially reasonable efforts to respond a
 |2.0             | General updates               | April 20, 2022 |
 |1.1             | Added support information     | April 7, 2021 |
 |1.0             | Initial version               | January 17, 2021 |
-


### PR DESCRIPTION
## Overview
This replaces links to the Zendesk-based articles with internal ones.

## Rationale
Zendesk-based knowledge-base are deprecated and no longer accessible by users.

Closes #CSP-138