### PR TITLE
Add parallel pipeline note to conditional page

### DIFF
--- a/_docs/pipelines/conditional-execution-of-steps.md
+++ b/_docs/pipelines/conditional-execution-of-steps.md
@@ -244,7 +244,7 @@ Try running the pipeline above and see how it behaves when a variable called `MY
 
 
 ## Single step dependencies
-When [parallel execution](https://codefresh.io/docs/docs/pipelines/advanced-workflows/#parallel-pipeline-execution) is enabled, the `when:` conditional can be used to set up step dependencies using the `steps:` and `on:` keywords. For more information, [check the parallel pipeline execution page](https://codefresh.io/docs/docs/pipelines/advanced-workflows/#parallel-pipeline-execution). 
+When [parallel execution]({{site.baseurl}}/docs/docs/pipelines/advanced-workflows/#parallel-pipeline-execution) is enabled, the `when:` conditional can be used to set up step dependencies using the `steps:` and `on:` keywords. For more information, [check the parallel pipeline execution page]({{site.baseurl}}/docs/docs/pipelines/advanced-workflows/#parallel-pipeline-execution). 
 
 ## Related articles
 [Codefresh YAML for pipeline definitions]({{site.baseurl}}/docs/pipelines/what-is-the-codefresh-yaml/)   

--- a/_docs/pipelines/conditional-execution-of-steps.md
+++ b/_docs/pipelines/conditional-execution-of-steps.md
@@ -242,6 +242,10 @@ Try running the pipeline above and see how it behaves when a variable called `MY
 
 >Notice that if you use this pattern a lot it means that you are trying to create a complex pipeline that is very smart. We suggest you create instead multiple [simple pipelines for the same project]({{site.baseurl}}/docs/ci-cd-guides/pull-request-branches/#trunk-based-development).
 
+
+## Single step dependencies
+When [parallel execution](https://codefresh.io/docs/docs/pipelines/advanced-workflows/#parallel-pipeline-execution) is enabled, the `when:` conditional can be used to set up step dependencies using the `steps:` and `on:` keywords. For more information, [check the parallel pipeline execution page](https://codefresh.io/docs/docs/pipelines/advanced-workflows/#parallel-pipeline-execution). 
+
 ## Related articles
 [Codefresh YAML for pipeline definitions]({{site.baseurl}}/docs/pipelines/what-is-the-codefresh-yaml/)   
 [Variables in pipelines]({{site.baseurl}}/docs/pipelines/variables/)  


### PR DESCRIPTION
heya, i was reviewing a teammates pipeline the other day where they used the `when: steps:` syntax for parallel pipelines. I didn't recongize that syntax from my sequential pipeline knowledge and it looked like a conditional, so i checked https://codefresh.io/docs/docs/pipelines/conditional-execution-of-steps/ this page and couldn't find anything about it. 

So i was thinking it'd be helpful if there was some note on that page about parallel usage. 

first PR, looked through https://github.com/codefresh-io/docs.codefresh.io/blob/fb80a7ee8ff463f7aae7a5a250ba46385b1c9c4a/.github/CONTRIBUTING.md , but please let me know if i missed something!

thanks
raptor