### PR TITLE
fix(triggers): fix markdown in Bitbucket Server events link

### DIFF
--- a/_docs/pipelines/triggers/git-triggers.md
+++ b/_docs/pipelines/triggers/git-triggers.md
@@ -131,7 +131,7 @@ For a description of the events and their payload, see [Bitbucket Cloud document
                         
 #### Bitbucket Server trigger events
 
-For a description of the events and their payload, see [Bitbucket Server documentation]https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html){:target="\_blank"}.
+For a description of the events and their payload, see [Bitbucket Server documentation](https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html){:target="\_blank"}.
 
 * Commit
 * Push commits


### PR DESCRIPTION
This fixes markdown for the link to the list of Bitbucket Server events.

Missed opening parenthesis caused link to be rendered wrong:
![image](https://github.com/codefresh-io/docs.codefresh.io/assets/114396046/a5afab96-7b96-43c0-9e00-3b7b273752a5)
