### PR TITLE
Update GTM container to use new id

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -49,7 +49,7 @@
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-WV3QT3W');</script>
+  })(window,document,'script','dataLayer','GTM-W57JFSTSH');</script>
 <!-- End Google Tag Manager -->
 
 <!--

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -49,7 +49,7 @@
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-W57JFSTSH');</script>
+  })(window,document,'script','dataLayer','GTM-57JFSTSH');</script>
 <!-- End Google Tag Manager -->
 
 <!--

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W57JFSTSH"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-57JFSTSH"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WV3QT3W"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W57JFSTSH"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -11,7 +11,7 @@ layout: compress
 
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WV3QT3W"
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W57JFSTSH"
       height="0" width="0" style="display:none;visibility:hidden"></iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -11,7 +11,7 @@ layout: compress
 
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W57JFSTSH"
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-57JFSTSH"
       height="0" width="0" style="display:none;visibility:hidden"></iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,7 +7,7 @@
 
   <!-- Google Tag Manager (noscript) -->
     <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WV3QT3W"
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W57JFSTSH"
       height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,7 +7,7 @@
 
   <!-- Google Tag Manager (noscript) -->
     <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W57JFSTSH"
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-57JFSTSH"
       height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/_layouts/no-header-footer.html
+++ b/_layouts/no-header-footer.html
@@ -7,7 +7,7 @@
 
   <!-- Google Tag Manager (noscript) -->
     <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WV3QT3W"
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W57JFSTSH"
       height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/_layouts/no-header-footer.html
+++ b/_layouts/no-header-footer.html
@@ -7,7 +7,7 @@
 
   <!-- Google Tag Manager (noscript) -->
     <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W57JFSTSH"
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-57JFSTSH"
       height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -33,7 +33,7 @@
   <body>
     <!-- Google Tag Manager (noscript) -->
     <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WV3QT3W"
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W57JFSTSH"
       height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
     <!-- End Google Tag Manager (noscript) -->

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -33,7 +33,7 @@
   <body>
     <!-- Google Tag Manager (noscript) -->
     <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W57JFSTSH"
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-57JFSTSH"
       height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
     <!-- End Google Tag Manager (noscript) -->


### PR DESCRIPTION
Problem
Our analytics, events, and other tracking are not loading on many pages and properties of Codefresh.

Cause
The previous Google Tag container (GTM-V3QT3W) was owned by [Sean Galliher](mailto:sean.galliher@codefresh.io), who is no longer with Codefresh. When his user was deleted, it removed the only admin from our Google Tag account. When that happened, the account was automatically deleted and cannot be recovered because no one has permission to the container.

Remediation
Replace old container GTM-V3QT3W with new container GTM-57JFSTSH

[Dan Garfield](mailto:dan@codefresh.io) had read access to the deleted account and could export everything and import it into a new container (GTM-57JFSTSH).