### PR TITLE
Update github-actions.md CF_GIT_BRANCH typo

### DIFF
--- a/_docs/gitops-integrations/ci-integrations/github-actions.md
+++ b/_docs/gitops-integrations/ci-integrations/github-actions.md
@@ -201,10 +201,10 @@ This example illustrates how to define the value for `CF_GIT_BRANCH` to report o
 
 
 Value:  
-{% raw %}`${{ github.ref-name }}`{% endraw %}  
+{% raw %}`${{ github.ref_name }}`{% endraw %}  
 
 where: 
-* {% raw %}`${{ github.ref-name }}`{% endraw %} is the name of the target branch or tag. For example, `auth-feature-branch`. 
+* {% raw %}`${{ github.ref_name }}`{% endraw %} is the name of the target branch or tag. For example, `auth-feature-branch`. 
 
 
 


### PR DESCRIPTION
`${{ github.ref-name }}` should be `${{ github.ref_name }}` https://docs.github.com/en/actions/learn-github-actions/contexts#github-context