### PR TITLE
replace parenthesis by bracket

### DIFF
--- a/_docs/pipelines/triggers/git-triggers.md
+++ b/_docs/pipelines/triggers/git-triggers.md
@@ -245,7 +245,7 @@ The default behavior triggers the pipeline on a commit action.
 Override the default behavior by adding any one of the predefined strings anywhere in the commit message.
 
 >**NOTE**  
-Remember to include the opening and closing parentheses when adding the strings. 
+Remember to include the opening and closing square brackets when adding the strings. 
 
 * `[skip ci]`
 * `[ci skip]`


### PR DESCRIPTION
[] are square brackets
so unless [], {}, () are accepted as well the correct word should be brackets

From lenovo.com:
What are the different types of brackets used in computing? There are several types of brackets used in computing, including parentheses (), square brackets [], and curly brackets {}