### PR TITLE
docs(kb): improve engine metrics doc

### DIFF
--- a/_docs/kb/articles/enable-engine-pod-metrics.md
+++ b/_docs/kb/articles/enable-engine-pod-metrics.md
@@ -7,7 +7,7 @@ toc: true
 kb: true
 ht: false
 common: false
-categories: [Runtimes, CLI]
+categories: [Runtimes]
 support-reviewed: 2023-04-18 LG
 ---
 
@@ -18,29 +18,64 @@ If you want to scrape the metrics from the Codefresh Runner to your existing Pro
 
 ## Details
 
-You will need to add the `METRICS_PROMETHEUS_ENABLED: 'true'` environment variable in your Runtime Environment spec.
+### How to enable
 
-To make the changes in your Runtime Environment, you will need to use the [Codefresh CLI.](https://codefresh-io.github.io/cli/installation/)
+You will need to add the `METRICS_PROMETHEUS_ENABLED: 'true'` environment variable for the engine pod.
 
-1. Get your Runtime Environment spec:
+To make such a change, you need to change Codefresh Runner Helm chart values. Full path to the entity in question is `runtime.engine.env.METRICS_PROMETHEUS_ENABLED`.
 
-   `codefresh get re <name> -o yaml > spec.yaml`
+Complete documentation on this and other environment variables available in the engine can be found on [Artifact Hub](https://artifacthub.io/packages/helm/codefresh-runner/cf-runtime?modal=values&path=runtime.engine.env).
 
-2. Modify\add the `envVar` section in `runtimeScheduler` in the downloaded
-file:
 
-    ```yaml  
-    ...  
-    runtimeScheduler:  
-      envVars:  
-        METRICS_PROMETHEUS_ENABLED: 'true'  
-      ...  
-      cluster:  
-        ...
-    ```
+### Available metrics
 
-3. Save the file and then patch your RE using the following CLI command:  
+Each of the metrics below has the following additional labels: `account_name`, `docker_node_address`, `pipeline_id`, `repo_branch`, `workflow`
 
-  `codefresh patch re -f spec.yaml`
-
-   Start a new build and check if you can scrape the metrics using port 9100 at the /metrics endpoint. The metrics in the dind pod should be enabled by default at the same port and endpoint.
+* `codefresh_engine_docker_daemon_requests_retries_delay_seconds_total`
+<br>Total delay in seconds for retry requests to Docker daemon
+<br>Type: Counter
+<br>Labels: `error`
+* `codefresh_engine_docker_daemon_requests_retries_total`
+<br>Total number of retry requests to Docker daemon
+<br>Type: Counter
+<br>Labels: `error`
+* `codefresh_workflow_composition_duration_seconds`
+<br>Composition duration in seconds
+<br>Type: Gauge
+<br>Labels: `composition_name`, `phase`
+* `codefresh_workflow_composition_phase_status`
+<br>Composition phase status: 1 for current status, 0 otherwise
+<br>Type: Gauge
+<br>Labels: `composition_name`, `phase`, `status`
+* `codefresh_workflow_composition_status`
+<br>Composition status: 1 for current status, 0 otherwise
+<br>Type: Gauge
+<br>Labels: `composition_name`, `status`
+* `codefresh_workflow_duration_seconds`
+<br>Workflow duration in seconds
+<br>Type: Gauge
+<br>Labels: `phase`
+* `codefresh_workflow_internal_images_reused`
+<br>1 if internal images were reused from cache by workflow, 0 otherwise
+<br>Type: Gauge
+<br>Labels: —
+* `codefresh_workflow_phase_status`
+<br>Workflow phase status: 1 for current status, 0 otherwise
+<br>Type: Gauge
+<br>Labels: `phase`, `status`
+* `codefresh_workflow_status`
+<br>Workflow status: 1 for current status, 0 otherwise
+<br>Type: Gauge
+<br>Labels: `status`
+* `codefresh_workflow_step_duration_seconds`
+<br>Workflow step duration in seconds
+<br>Type: Gauge
+<br>Labels: `phase`, `step_name`, `step_type`
+* `codefresh_workflow_step_status`
+<br>Workflow step status: 1 for current status, 0 otherwise
+<br>Type: Gauge
+<br>Labels: `phase`, `status`, `step_name`, `step_type`
+* `codefresh_workflow_volume_reused`
+<br>1 if the volume was reused by workflow, 0 otherwise
+<br>Type: Gauge
+<br>Labels: —


### PR DESCRIPTION
This adjusts instructions on how to enable engine metrics to the currently recommended installation way (Helm chart);

and also documents available metrics.