### PR TITLE
Update hybrid-gitops-helm-installation.md

### DIFF
--- a/_docs/installation/gitops/hybrid-gitops-helm-installation.md
+++ b/_docs/installation/gitops/hybrid-gitops-helm-installation.md
@@ -290,7 +290,7 @@ Install the Hybrid GitOps Runtime through the Helm chart. The Codefresh `values.
 
 
 **Runtime Name**  
-If you define a custom name for the Hybrid GitOps Runtime, it must start with a lower-case character, and can include up to 62 lower-case characters and numbers.
+If you define a custom name for the Hybrid GitOps Runtime, it must start with a lower-case character, and can include up to 38 lower-case characters and numbers.
 
 **Namespace**  
 The Namespace must conform to the naming conventions for Kubernetes objects.


### PR DESCRIPTION
Updated max characters for runtime names to 38 as per CR-24378