### PR TITLE
Add section for MAX_UPLOAD_SIZE_MB env var

### DIFF
--- a/_docs/testing/test-reports.md
+++ b/_docs/testing/test-reports.md
@@ -504,7 +504,7 @@ If you don't provide a `REPORT_TYPE`, Codefresh uses a default icon.
 
 ## Uploading large test reports
 
-By default, the maximum size for a test report is 1000MB. If that is not enough, the max size can be overriden with the environment variable `MAX_UPLOAD_SIZE_MB`.
+By default, the maximum size for a test report is 1000MB. Override the default max limit through the `MAX_UPLOAD_SIZE_MB` environment variable, as in the following example.
 
 Example:
 

--- a/_docs/testing/test-reports.md
+++ b/_docs/testing/test-reports.md
@@ -504,7 +504,7 @@ If you don't provide a `REPORT_TYPE`, Codefresh uses a default icon.
 
 ## Uploading large test reports
 
-By default, the maximum size for a test report is 1000MB. Override the default max limit through the `MAX_UPLOAD_SIZE_MB` environment variable, as in the following example.
+By default, the maximum size for a test report is 1000MB. Override the default size through the `MAX_UPLOAD_SIZE_MB` environment variable.
 
 Example:
 

--- a/_docs/testing/test-reports.md
+++ b/_docs/testing/test-reports.md
@@ -502,6 +502,27 @@ The icons shown are specified by the `REPORT_TYPE` variable. The following optio
 
 If you don't provide a `REPORT_TYPE`, Codefresh uses a default icon.
 
+## Uploading large test reports
+
+By default, the maximum size for a test report is 1000MB. If that is not enough, the max size can be overriden with the environment variable `MAX_UPLOAD_SIZE_MB`.
+
+Example:
+
+{% highlight yaml %}
+{% raw %}
+unit_test_reporting_step:
+title: Upload Mocha test reports
+image: codefresh/cf-docker-test-reporting
+working_directory: /codefresh/volume/demochat/
+environment:
+- REPORT_DIR=mochawesome-report
+- REPORT_INDEX_FILE=mochawesome.html
+- CLEAR_TEST_REPORT=true
+- BUCKET_NAME=my-bucket-name
+- CF_STORAGE_INTEGRATION=google
+- MAX_UPLOAD_SIZE_MB=3000
+{% endraw %}
+{% endhighlight %}
 
 ## Getting results from tests that fail
 


### PR DESCRIPTION
I added a new env var to `cf-docker-test-reporting` which allows users to override the max upload size of a test report:
https://github.com/codefresh-io/cf-docker-test-reporting/pull/175

This PR just adds some documentation to point users at this new environment variable.

<img width="772" alt="Screenshot 2024-09-06 at 10 12 54" src="https://github.com/user-attachments/assets/daa11a22-47bd-45a5-a7f6-3fb90ba6a612">