### PR TITLE
Updates as per legal

### DIFF
--- a/_docs/terms-and-privacy-policy/octopus-deploy-customer-agreement.md
+++ b/_docs/terms-and-privacy-policy/octopus-deploy-customer-agreement.md
@@ -6,5 +6,5 @@ toc: true
 ---
 
 
-For the Octopus Deploy Customer Agreement, click [here](https://i.octopus.com/trust/Octopus+Deploy+Customer+Agreement+(Complete)+1+October+2024.pdf){:target="\_blank"}.
+For the Octopus Deploy Customer Agreement, click [here](https://i.octopus.com/trust/octopus-customer-agreement-2025.pdf){:target="\_blank"}.
 

--- a/_docs/terms-and-privacy-policy/sla.md
+++ b/_docs/terms-and-privacy-policy/sla.md
@@ -74,6 +74,7 @@ issue as defined below and will use commercially reasonable efforts to respond a
 | Normal        | Errors that cause previously-working non-critical features to malfunction. |
 | Low | General questions, How-Tos, best practices questions, and feature requests.|
 
+[Severity Examples]({{site.baseurl}}/docs/terms-and-privacy-policy/support-triage-definitions/).
 
 **3.3. Support Channels**. 
 

--- a/_docs/terms-and-privacy-policy/terms-of-service.md
+++ b/_docs/terms-and-privacy-policy/terms-of-service.md
@@ -8,7 +8,6 @@ redirect_from:
 toc: true
 ---
 >Codefresh was acquired by Octopus Deploy in March 2024. Starting 1 October 2024, you can buy Codefresh through Octopus Deploy's umbrella Customer Agreement.  
-If you would like to see our legacy terms of service up to 30 September 2024, click [here]({{site.baseurl}}/docs/terms-and-privacy-policy/legacy-cf-terms-of-service/). 
 
 Our complete Customer Agreement with you has four parts:
 
@@ -51,8 +50,6 @@ Our complete Customer Agreement with you has four parts:
     </td>
 </table>
 {:/}
-
-You can download our current Customer Agreement here: [Octopus Deploy Customer Agreement](https://i.octopus.com/trust/Octopus+Deploy+Customer+Agreement+(Complete)+1+October+2024.pdf){:target="\_blank"}
 
 
 If you require a signed copy of the Customer Agreement for your records, please contact [sales@codefresh.io](mailto:sales@codefresh.io).


### PR DESCRIPTION
Updated link in customer agreement; removed references to legacy terms of service; restored link to support triage examples in enterprise SLA