### PR TITLE
Move legacy side-by-side install in nav

### DIFF
--- a/_data/home-content.yml
+++ b/_data/home-content.yml
@@ -212,8 +212,7 @@
       localurl: /docs/installation/gitops/runtime-install-with-existing-argo-cd/
     - title: Install GitOps Runtime with new Argo CD
       localurl: /docs/installation/gitops/hybrid-gitops-helm-installation/
-    - title: Migrate Hybrid GitOps Runtimes from CLI to Helm
-      localurl: /docs/installation/gitops/migrate-cli-runtimes-helm/
+
 
 - title: Administration
   icon: images/home-icons/administration.svg

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -594,9 +594,7 @@
           url: "/behind-the-firewall"
     - title: GitOps Runtimes
       url: "/gitops"
-      sub-pages:
-        - title: What's changed in GitOps Runtimes documentation
-          url: "/gitops-runtimes-whats-changed"        
+      sub-pages:     
         - title: GitOps Runtime architecture
           url: "/runtime-architecture"
         - title: Runtime concepts
@@ -610,9 +608,7 @@
         - title: Install GitOps Runtime with existing Argo CD
           url: "/runtime-install-with-existing-argo-cd"                       
         - title: Install GitOps Runtime with new Argo CD
-          url: "/hybrid-gitops-helm-installation" 
-        - title: Install GitOps Runtime alongside Community Argo CD
-          url: "/argo-with-gitops-side-by-side"        
+          url: "/hybrid-gitops-helm-installation"      
         - title: On-premises GitOps Runtime
           url: "/on-prem-gitops-runtime-install"
         - title: Runtime values file validation
@@ -623,8 +619,6 @@
           url: "/runtime-install-ingress-service-mesh-access-mode"   
         - title: Ingress configuration
           url: "/runtime-ingress-configuration" 
-        - title: Migrating GitOps Runtimes from CLI to Helm
-          url: "/migrate-cli-runtimes-helm"  
         - title: Shared Configuration Repository
           url: "/shared-configuration"
         - title: Configuration Runtimes
@@ -639,7 +633,10 @@
           url: "/git-sources"
         - title: Download/upgrade GitOps CLI
           url: "/upgrade-gitops-cli"   
-
+        - title: Migrating GitOps Runtimes from CLI to Helm
+          url: "/migrate-cli-runtimes-helm"  
+        - title: Install GitOps Runtime alongside Community Argo CD
+          url: "/argo-with-gitops-side-by-side"   
 
 
 - title: Administration

--- a/_docs/installation/gitops/argo-with-gitops-side-by-side.md
+++ b/_docs/installation/gitops/argo-with-gitops-side-by-side.md
@@ -6,7 +6,7 @@ toc: true
 
 {{site.data.callout.callout_warning}}
 **LEGACY INSTALLATION**  
-This installation method is no longer recommended. If you have your own Argo CD instance, use the new approach in [Installing GitOps Runtimes with existing Argo CD]({{site.baseurl}}/docs/installation/gitops/runtime-install-with-existing-argo-cd/).
+This installation method is no longer recommended. If you have your own Argo CD instance, see [Installing GitOps Runtimes with existing Argo CD]({{site.baseurl}}/docs/installation/gitops/runtime-install-with-existing-argo-cd/).
 {{site.data.callout.end}}
 
 ## GitOps Runtime alongside Community Argo CD

--- a/_docs/installation/gitops/argo-with-gitops-side-by-side.md
+++ b/_docs/installation/gitops/argo-with-gitops-side-by-side.md
@@ -4,6 +4,10 @@ description: "Install GitOps Runtime on cluster with existing Argo CD"
 toc: true
 ---
 
+{{site.data.callout.callout_warning}}
+**LEGACY INSTALLATION**  
+This installation method is no longer recommended. If you have your own Argo CD instance, use the new approach in [Installing GitOps Runtimes with existing Argo CD]({{site.baseurl}}/docs/installation/gitops/runtime-install-with-existing-argo-cd/).
+{{site.data.callout.end}}
 
 ## GitOps Runtime alongside Community Argo CD
 If you have a cluster with a version of Community Argo CD already installed, you can install the GitOps Runtime to co-exist with your existing Argo CD installation.  This option enables you to extend your environment with Codefresh's GitOps capabilities through a few simple configuration changes, without the need to uninstall Argo CD. 


### PR DESCRIPTION
Moved side-by-side argo cd with gitops to bottom of installation bucket and added deprecation note at the top of the topic