### PR TITLE
Separate promotions into simple and advanced

### DIFF
--- a/_data/argohub-home-content.yml
+++ b/_data/argohub-home-content.yml
@@ -24,12 +24,12 @@
       localurl: /gitops/gitops-quick-start/create-app-ui/
     - title: Creating environments
       localurl: /gitops/gitops-quick-start/quick-start-gitops-environments/
-    - title: Creating Promotion Workflows
-      localurl: /gitops/gitops-quick-start/quick-start-promotion-workflow/
     - title: Simple promotion with drag-and-drop 
       localurl: /gitops/gitops-quick-start/drag-and-drop/
     - title: Simple Promotion Flow with multiple environments
       localurl: /gitops/gitops-quick-start/multi-env-sequential-flow/ 
+    - title: Creating Promotion Workflows
+      localurl: /gitops/gitops-quick-start/quick-start-promotion-workflow/
     - title: Advanced Promotion Flow with Promotion Workflows
       localurl: /gitops/gitops-quick-start/policy-multi-env-promotion/
     - title: Advanced Promotion Flow with environment dependencies

--- a/_data/argohub-nav.yml
+++ b/_data/argohub-nav.yml
@@ -22,12 +22,12 @@
       url: "/create-app-ui"
     - title: Creating environments
       url: "/quick-start-gitops-environments"
-    - title: Creating Promotion Workflows
-      url: "/quick-start-promotion-workflow"  
     - title: Simple promotion with drag-and-drop 
       url: "/drag-and-drop"    
     - title: Simple Promotion Flow with multiple environments
       url: "/multi-env-sequential-flow"  
+    - title: Creating Promotion Workflows
+      url: "/quick-start-promotion-workflow"  
     - title: Advanced Promotion Flow with Promotion Workflows
       url: "/policy-multi-env-promotion"  
     - title: Advanced Promotion Flow with environment dependencies

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -28,12 +28,12 @@
     - title: Creating products and applications
       url: "/create-app-ui"
     - title: Creating environments
-      url: "/quick-start-gitops-environments"
-    - title: Creating Promotion Workflows
-      url: "/quick-start-promotion-workflow"  
+      url: "/quick-start-gitops-environments" 
     - title: Simple promotion with drag-and-drop 
       url: "/drag-and-drop"    
     - title: Simple Promotion Flow with multiple environments
+    - title: Creating Promotion Workflows
+      url: "/quick-start-promotion-workflow" 
       url: "/multi-env-sequential-flow"      
     - title: Advanced Promotion Flow with Promotion Workflows
       url: "/policy-multi-env-promotion"  

--- a/_docs/gitops-quick-start/drag-and-drop.md
+++ b/_docs/gitops-quick-start/drag-and-drop.md
@@ -135,7 +135,7 @@ max-width="60%"
 
 
 ## What's next
-Now that you've learned how to promote a product using the drag-and-drop method, we'll explore more advanced promotion scenarios.  
+Now that you've learned how to promote a product using the drag-and-drop method, we'll explore a more advanced promotion scenario.  
 The next quick start describes how to orchestrate a promotion through a Promotion Flow, which automates deployments across more than two environments.
 
 [Quick start: Simple Promotion Flow with multiple environments]({{site.baseurl}}/docs/gitops-quick-start/multi-env-sequential-flow/)

--- a/_docs/gitops-quick-start/gitops-quick-start.md
+++ b/_docs/gitops-quick-start/gitops-quick-start.md
@@ -37,19 +37,24 @@ We've provided a GitHub repository with all the applications and resources used 
 * [Creating environments]({{site.baseurl}}/docs/gitops-quick-start/quick-start-gitops-environments/)  
   Define and manage environments such as development and production, enabling structured application deployments across different stages.
 
-* [Creating Promotion Workflows]({{site.baseurl}}/docs/gitops-quick-start/quick-start-promotion-workflow/)   
-  Automate pre- and post-promotion actions during GitOps promotions in environments, ensuring quality, security, and compliance at each stage.
 
 
-## Promoting applications
+
+## Simple promotions for applications
 
 Promote and deploy changes in applications across environments.
-Start with simple manual promotion, then automate with Promotion Flows—evolving from simple sequential promotions to advanced ones with environment dependencies.
+Start with simple manual promotion across two environments, then automate across multiple environments with a simple Promotion Flows.
 
 * [Simple drag-and-drop promotion]({{site.baseurl}}/docs/gitops-quick-start/drag-and-drop/)  
   Manually promote a product between two environments.
 * [Simple Promotion Flow with multiple environments]({{site.baseurl}}/docs/gitops-quick-start/multi-env-sequential-flow/)  
   Automate promotions across multiple environments sequentially using a simple Promotion Flow.
+
+## Advanced promotions for applications
+Evolve from simple sequential promotions to advanced application promotion scenarios with validations and environment dependencies.
+
+* [Creating Promotion Workflows]({{site.baseurl}}/docs/gitops-quick-start/quick-start-promotion-workflow/)   
+  Automate pre- and post-promotion actions during GitOps promotions in environments, ensuring quality, security, and compliance at each stage.
 * [Advanced Promotion Flow with Promotion Workflows]({{site.baseurl}}/docs/gitops-quick-start/policy-multi-env-promotion/)  
   Control promotion behavior for environments using Promotion Workflows within a Promotion Flow.
 * [Advanced Promotion Flow with environment dependencies]({{site.baseurl}}/docs/gitops-quick-start/dependency-multi-env-promotion/)  

--- a/_docs/gitops-quick-start/multi-env-sequential-flow.md
+++ b/_docs/gitops-quick-start/multi-env-sequential-flow.md
@@ -263,9 +263,15 @@ spec:
 
 
 ## What's next
-The next quick start will guide you through adding Promotion Workflows to each environment in a Promotion Flow. Promotion Workflows act as gates for conditional promotions, giving you more control and flexibility over promotion processes.
+Before we move to more advanced scenarios for promotion applications, we'll create another key entity which enhances the promotion process—Promotion Workflows.  
+Promotion Workflows are used in automated promotion flows to enforce quality, security, and compliance requirements at each stage of the promotion.
 
-[Quick start: Advanced Promotion Flow with Promotion Workflows]({{site.baseurl}}/docs/gitops-quick-start/policy-multi-env-promotion/)
+[Quick start: Creating Promotion Workflows]({{site.baseurl}}/docs/gitops-quick-start/quick-start-promotion-workflow/)
+
+
+
+
+
 
  
  

--- a/_docs/gitops-quick-start/policy-multi-env-promotion.md
+++ b/_docs/gitops-quick-start/policy-multi-env-promotion.md
@@ -11,7 +11,7 @@ redirect_from:
 
 Promotion Flows allow you to [automate promotions across multiple environments]({{site.baseurl}}/docs/gitops-quick-start/multi-env-sequential-flow/). 
 
-This quick start explores how to enhance Promotion Flows by configuring conditions for each environment through Promotion Workflows.  
+This quick start explores how to enhance Promotion Flows by configuring Promotion Workflows for each environment.  
 Promotion Workflows define the conditions under which changes are promoted to the next environment. They automate testing, validation, and other required checks, establishing gates to enforce promotion criteria.
 
 For this quick start, we'll use the same Promotion Workflows created in [Quick Start: Creating Promotion Workflows]({{site.baseurl}}/docs/gitops-quick-start/quick-start-promotion-workflow) within the Promotion Flow.

--- a/_docs/gitops-quick-start/quick-start-gitops-environments.md
+++ b/_docs/gitops-quick-start/quick-start-gitops-environments.md
@@ -101,8 +101,9 @@ Here's an example of the Environments dashboard with the three environments, and
 
 
 ## What's next
-Now that you've set up environments, we'll focus on another key entity in GitOps promotions which enhances the promotion process—Promotion Workflows.  
-Promotion Workflows are used in automated promotion flows to enforce quality, security, and compliance requirements at each stage of the promotion.
+Now that you've set up environments, and the other entities required for GitOps-based promotions, you can trigger promotions to move application versions across environments.
 
-[Quick start: Creating Promotion Workflows]({{site.baseurl}}/docs/gitops-quick-start/quick-start-promotion-workflow/)
+We'll start with a simple drag-and-drop promotion.
+
+[Quick start: Simple promotion with drag-and-drop]({{site.baseurl}}/docs/gitops-quick-start/drag-and-drop/)
 

--- a/_docs/gitops-quick-start/quick-start-promotion-workflow.md
+++ b/_docs/gitops-quick-start/quick-start-promotion-workflow.md
@@ -243,8 +243,6 @@ For example, you can configure the ServiceNow Promotion Workflow in example 2 as
 
 
 ## What's next
-Now that you have created all the entities required for GitOps-based promotions, you can trigger promotions to move application versions across environments.
+The next quick start will guide you through adding Promotion Workflows to each environment in a Promotion Flow. Promotion Workflows act as gates for conditional promotions, giving you more control and flexibility over promotion processes.
 
-We'll start with a simple drag-and-drop promotion.
-
-[Quick start: Simple promotion with drag-and-drop]({{site.baseurl}}/docs/gitops-quick-start/drag-and-drop/)
+[Quick start: Advanced Promotion Flow with Promotion Workflows]({{site.baseurl}}/docs/gitops-quick-start/policy-multi-env-promotion/)


### PR DESCRIPTION
Updated quick start overview to have two groups for simple and advanced promotions. Moved Creating promotion workflows to Advanced promotion groups. Updated all what's nexts accordingly