### PR TITLE
fix: Reverse order of posts in gitops changelog

### DIFF
--- a/_gitops/whats-new/changelog.md
+++ b/_gitops/whats-new/changelog.md
@@ -9,11 +9,12 @@ If you missed any of our previous online announcements, you can find the latest 
 
 > To subscribe to an RSS / Atom feed for our SaaS release notes, please [click here]({{ site.baseurl }}/changelog/gitops.xml).
 
-{% assign posts_by_year = site.posts-gitops | group_by_exp: "post", "post.date | date: '%Y'" %}
+{% assign posts_by_year = site.posts-gitops | group_by_exp: "post", "post.date | date: '%Y'" | reverse %}
 {% for year in posts_by_year %}
   <h2>{{ year.name }}</h2>
   <ul>
-    {% for post in year.items %}
+    {% assign sorted_posts = year.items | reverse %}
+    {% for post in sorted_posts %}
       <li>
         <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
       </li>


### PR DESCRIPTION
Fixes post sorting within year groups in the GitOps changelog. Posts are now correctly sorted by date in descending order within each group.