### PR TITLE
Fix helm add-cluster values file link

### DIFF
--- a/_docs/installation/gitops/managed-cluster.md
+++ b/_docs/installation/gitops/managed-cluster.md
@@ -87,7 +87,7 @@ For ingress-based GitOps Runtimes, to get the `ingressUrl` for your, first authe
 The Helm chart is published at oci://quay.io/codefresh/charts/csdp-add-cluster. You can see the source templates at [https://github.com/codefresh-io/csdp-official/tree/main/add-cluster/helm](https://github.com/codefresh-io/csdp-official/tree/main/add-cluster/helm){:target="\_blank"}.
 
 To deploy the chart:
-1. Copy the [values.yaml](https://github.com/codefresh-io/gitops-runtime-helm/blob/main/charts/gitops-runtime/values.yaml){:target="\_blank"} file locally.
+1. Copy the [values.yaml](https://github.com/codefresh-io/csdp-official/blob/main/add-cluster/helm/values.yaml){:target="\_blank"} file locally.
 1. Fill in the required values.
 1. Run:
 ```shell


### PR DESCRIPTION
We have a wrong values.yaml link in GitOps cluster add with Helm:
https://codefresh.io/docs/docs/installation/gitops/managed-cluster/#add-a-managed-cluster-with-helm

It is pointing to GitOps runtime values:
https://github.com/codefresh-io/gitops-runtime-helm/blob/main/charts/gitops-runtime/values.yaml

But it should point to add-cluster chart values:
https://github.com/codefresh-io/csdp-official/blob/main/add-cluster/helm/values.yaml

Slack: https://octopusdeploy.slack.com/archives/C0751HU4BLG/p1750409347947289