### PR TITLE
Update OIDC Okta documentation with API permissions note

### DIFF
--- a/_docs/administration/single-sign-on/oidc/oidc-okta.md
+++ b/_docs/administration/single-sign-on/oidc/oidc-okta.md
@@ -120,6 +120,8 @@ caption="API token in Okta to use as Access token"
 max-width="60%"
 %}
 
+> **Note:**
+> The api permission you can use is the built-in Read Only Admin role
   
 {% include image.html 
 lightbox="true" 


### PR DESCRIPTION
Added note about using the built-in Read Only Admin role for API permissions.