### PR TITLE
feat: add documentation for Codefresh API keys rate limiter under sec…

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -731,6 +731,8 @@
       url: "/codefresh-signed-artifacts"
     - title: Verify authenticity of artifacts signed with Codefresh pipelines
       url: "/pipelines-verify-cf-artifacts"
+    - title: Codefresh API keys rate limiter
+      url: "/api-key-rate-limiting"
 
 - title: What's new
   url: "/whats-new"

--- a/_docs/security/api-key-rate-limiting.md
+++ b/_docs/security/api-key-rate-limiting.md
@@ -1,0 +1,18 @@
+---
+title: "Codefresh API keys rate limiter"
+description: "Understand rate limiting behavior for Codefresh API keys"
+group: security
+toc: true
+---
+
+## Codefresh API keys rate limiter
+
+To ensure platform stability and fair usage across all accounts, API requests are subject to rate limiting on a per Codefresh API-key basis.
+
+Specific rate limit thresholds may vary and are subject to change without prior notice.
+
+If your application exceeds the allowed request rate, the API will respond with HTTP status `429 Too Many Requests`.
+
+If access has been restricted for your API key due to unusual activity, the API will respond with HTTP status `403 Forbidden`.
+
+Design your integrations to handle `429` responses gracefully rather than relying on a fixed request budget.


### PR DESCRIPTION
add documentation for Codefresh API keys rate limiter under security 
link to internal runbook doc: https://octopushq.atlassian.net/wiki/spaces/RDC1/pages/4076208178/Rate+Limiting+Incident+Runbook