### PR TITLE
Remove community links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -157,7 +157,6 @@ link_cli:             "https://github.com/codefresh-io/cli-v2#installation"
 link_git_examples:    "https://github.com/codefresh-examples/examples/"
 link_api:             "https://g.codefresh.io/api/"
 link_plugins:         "https://codefresh.io/argohub/"
-link_community:       "https://community.codefresh.io/"
 
 gitops_collection:     "gitops"
 

--- a/_includes/argohub-docs-navbar.html
+++ b/_includes/argohub-docs-navbar.html
@@ -56,9 +56,6 @@
         </li>
       -->
         <li class="nav-item">
-          <a class="nav-link" href="{{ site.link_community }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open Community');" target="_blank" rel="noopener">Community</a>
-        </li>
-        <li class="nav-item">
           <a class="nav-link" href="https://gitops-graphql-docs.codefresh.io/introduction/welcome" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open API Swagger');" target="_blank" rel="noopener">API</a>
         </li>
         <li class="nav-item">

--- a/_includes/docs-navbar.html
+++ b/_includes/docs-navbar.html
@@ -55,9 +55,6 @@
           <a class="nav-link" href="{{ site.link_plugins }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open Plugins');" target="_blank" rel="noopener">Plugins</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="{{ site.link_community }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open Community');" target="_blank" rel="noopener">Community</a>
-        </li>
-        <li class="nav-item">
           <a class="nav-link" href="{{ site.baseurl }}/docs/installation/cli/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open CLI Docs');">CLI</a>
         </li>
         <li class="nav-item">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,9 +6,6 @@
       <li>
         <a class="text-uppercase" href="{{ site.link_plugins }}" onclick="ga('send', 'event', 'Footer', 'Docs links', 'Open Plugins');" target="_blank" rel="noopener">Plugins</a>
       </li>
-      <li>
-        <a class="text-uppercase" href="{{ site.link_community }}" onclick="ga('send', 'event', 'Footer', 'Docs links', 'Open Community');" target="_blank" rel="noopener">Community</a>
-      </li>
 {% endcomment %}
     </ul>
     <p>&copy; {{ 'now' | date: '%Y' }} <a href="https://codefresh.io">Codefresh.io</a></p>


### PR DESCRIPTION
Prepare to decommission the Discord board. I'm removing the community links from docs as we will shut that service down this year due to inactivity.