### PR TITLE
docs: mark promotions as disabled across environments

### DIFF
--- a/_docs/dashboards/gitops-environments.md
+++ b/_docs/dashboards/gitops-environments.md
@@ -5,6 +5,8 @@ group: dashboards
 toc: true
 ---
 
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Environments dashboard
 The **Environments** dashboard introduces a new dimension to the developer and deployment experience with Argo CD applications in Codefresh.

--- a/_docs/dashboards/gitops-products.md
+++ b/_docs/dashboards/gitops-products.md
@@ -5,8 +5,8 @@ group: dashboards
 toc: true
 ---
 
-
-
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 Explore the power of products for Argo CD applications in Codefresh GitOps. 
 

--- a/_docs/environments/create-manage-environments.md
+++ b/_docs/environments/create-manage-environments.md
@@ -5,6 +5,9 @@ group: environments
 toc: true
 ---
 
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
+
 ## Creating and managing environments
 Environments provide a structured way to manage Argo CD applications across different stages of development and deployment. By defining environments, teams can control how applications are deployed, tested, and promoted. Environments in Codefresh GitOps integrate with products and applications, providing visibility and governance over deployments.
 

--- a/_docs/environments/environments-overview.md
+++ b/_docs/environments/environments-overview.md
@@ -5,7 +5,8 @@ group: environments
 toc: true
 ---
 
-
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Environments in Codefresh GitOps
 An environment in Codefresh GitOps is a logical grouping of one or more Kubernetes clusters and namespaces, representing a deployment context for your Argo CD applications. Environments provide visibility into all Argo CD applications deployed within these clusters and namespaces, enabling teams to track application states at a glance.

--- a/_docs/environments/manage-apps-in-environments.md
+++ b/_docs/environments/manage-apps-in-environments.md
@@ -5,7 +5,8 @@ group: environments
 toc: true
 ---
 
-
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Working with products and applications in environments
 Environments provide visibility into which applications are running where. If you have created products to group applications, environments display the products, and their associated applications. If there are no products, the dashboard displays individual applications.

--- a/_docs/gitops-quick-start/dependency-multi-env-promotion.md
+++ b/_docs/gitops-quick-start/dependency-multi-env-promotion.md
@@ -7,9 +7,8 @@ redirect_from:
   - /docs/promotions/promotion-scenarios/dependency-multi-env-promotion/
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Advanced Promotion Flow with environment dependencies quick start
 

--- a/_docs/gitops-quick-start/drag-and-drop.md
+++ b/_docs/gitops-quick-start/drag-and-drop.md
@@ -7,10 +7,8 @@ redirect_from:
   - /docs/promotions/promotion-scenarios/drag-and-drop/
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
-
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Simple drag-and-drop promotion quick start
 In this first quick start on promotions, we'll see how to promote products using the intuitive drag-and-drop functionality in the Environments dashboard. 

--- a/_docs/gitops-quick-start/gitops-quick-start.md
+++ b/_docs/gitops-quick-start/gitops-quick-start.md
@@ -8,11 +8,11 @@ redirect_from:
 ---
 
 ## GitOps quick starts: From start to deployment 
-Codefresh GitOps simplifies software delivery with automation, consistency, and scalability. These quick start guides provide step-by-step instructions to help you quickly set up, manage, and promote applications with Codefresh GitOps.
+Codefresh GitOps simplifies software delivery with automation, consistency, and scalability. These quick start guides provide step-by-step instructions to help you quickly set up, manage, and deploy applications with Codefresh GitOps.
 
-Each quick start is standalone, so you can explore specific topics as needed. However, for maximum value, the quick starts are designed to build upon each other, taking you on a journey from setup to seamless application promotion across environments.
+Each quick start is standalone, so you can explore specific topics as needed. However, for maximum value, the quick starts are designed to build upon each other, taking you on a journey from setup to deploying applications.
 
-The journey begins with setting up your account and installing the GitOps Runtime. From there, you’ll define environments, products, and applications, leading to deploying and promoting applications effectively across multiple environments.
+The journey begins with setting up your account and installing the GitOps Runtime. From there, you’ll define environments, products, and applications, leading to deploying applications effectively across your clusters.
 
 We've provided a GitHub repository with all the applications and resources used in the quick starts. You can follow along directly or fork the repository to create and manage your own applications.
 
@@ -30,7 +30,7 @@ We've provided a GitHub repository with all the applications and resources used 
   Configure the GitOps Runtime for successful operation.
 
 
-## Creating GitOps entities for promotions
+## Creating GitOps entities
 * [Creating products and applications]({{site.baseurl}}/docs/gitops-quick-start/create-app-ui/)   
   Create Argo CD applications, the product to link them to, and configure their source repositories, manifests, and deployment paths.
 
@@ -38,30 +38,8 @@ We've provided a GitHub repository with all the applications and resources used 
   Define and manage environments such as development and production, enabling structured application deployments across different stages.
 
 
-
-
-## Simple promotions for applications
-
-Promote and deploy changes in applications across environments.
-Start with simple manual promotion across two environments, then automate across multiple environments with a simple Promotion Flows.
-
-* [Simple drag-and-drop promotion]({{site.baseurl}}/docs/gitops-quick-start/drag-and-drop/)  
-  Manually promote a product between two environments.
-* [Simple Promotion Flow with multiple environments]({{site.baseurl}}/docs/gitops-quick-start/multi-env-sequential-flow/)  
-  Automate promotions across multiple environments sequentially using a simple Promotion Flow.
-
-## Advanced promotions for applications
-Evolve from simple sequential promotions to advanced application promotion scenarios with validations and environment dependencies.
-
-* [Creating Promotion Workflows]({{site.baseurl}}/docs/gitops-quick-start/quick-start-promotion-workflow/)   
-  Automate pre- and post-promotion actions during GitOps promotions in environments, ensuring quality, security, and compliance at each stage.
-* [Advanced Promotion Flow with Promotion Workflows]({{site.baseurl}}/docs/gitops-quick-start/policy-multi-env-promotion/)  
-  Control promotion behavior for environments using Promotion Workflows within a Promotion Flow.
-* [Advanced Promotion Flow with environment dependencies]({{site.baseurl}}/docs/gitops-quick-start/dependency-multi-env-promotion/)  
-  Run promotions with defined dependencies between environments using an advanced Promotion Flow.
-
-
-  
+> **Note**  
+> Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0. The promotion quick starts are no longer part of this journey.
 
 ## Example Git repository
 

--- a/_docs/gitops-quick-start/multi-env-sequential-flow.md
+++ b/_docs/gitops-quick-start/multi-env-sequential-flow.md
@@ -7,10 +7,8 @@ redirect_from:
   - /docs/promotions/promotion-scenarios/multi-env-sequential-flow/
 ---
 
-
-
-
-
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Simple Promotion Flow with multiple environments quick start
 [Drag-and-drop promotion]({{site.baseurl}}/docs/gitops-quick-start/drag-and-drop/) is ideal for on-demand promotions to a single environment.  

--- a/_docs/gitops-quick-start/parallel-multi-env-promotion.md
+++ b/_docs/gitops-quick-start/parallel-multi-env-promotion.md
@@ -7,8 +7,8 @@ redirect_from:
   - /docs/promotions/promotion-scenarios/parallel-multi-env-promotion/
 ---
 
-
-
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Advanced Promotion Flow with parallel environments quick start
 

--- a/_docs/gitops-quick-start/policy-multi-env-promotion.md
+++ b/_docs/gitops-quick-start/policy-multi-env-promotion.md
@@ -7,6 +7,9 @@ redirect_from:
   - /docs/promotions/promotion-scenarios/policy-multi-env-promotion/
 ---
 
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
+
 ## Advanced Promotion Flow with Promotion Workflows quick start
 
 Promotion Flows allow you to [automate promotions across multiple environments]({{site.baseurl}}/docs/gitops-quick-start/multi-env-sequential-flow/). 

--- a/_docs/gitops-quick-start/promotions.md
+++ b/_docs/gitops-quick-start/promotions.md
@@ -7,6 +7,8 @@ redirect_from:
   - /docs/promotions/promotion-scenarios/
 ---
 
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 Promotions orchestrate the flow of changes for applications across environments, ensuring controlled and validated deployments. 
 A successful promotion sequence relies on several key components that together govern and orchestrate the promotion flow across environments. 

--- a/_docs/gitops-quick-start/quick-start-promotion-workflow.md
+++ b/_docs/gitops-quick-start/quick-start-promotion-workflow.md
@@ -5,9 +5,8 @@ group: gitops-quick-start
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Promotion Workflows quick start
 This quick start will guide you through creating a Promotion Workflow in Codefresh.  

--- a/_docs/products/about-products.md
+++ b/_docs/products/about-products.md
@@ -5,8 +5,8 @@ group: products
 toc: true
 ---
 
-
-
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Products in Codefresh GitOps
 Harness the power of **products** in Codefresh GitOps to streamline the management and deployment of Argo CD applications. 

--- a/_docs/products/assign-applications.md
+++ b/_docs/products/assign-applications.md
@@ -5,6 +5,9 @@ group: products
 toc: true
 ---
 
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
+
 After creating a product, the next step is to assign applications to it.
 Assigning applications to a product groups these applications into a single cohesive entity, making it easier to manage promotions and deployments.
 

--- a/_docs/products/configure-product-settings.md
+++ b/_docs/products/configure-product-settings.md
@@ -5,6 +5,9 @@ group: products
 toc: true
 ---
 
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
+
 ## Product settings
 After creating a product, optimize its functionality by configuring different settings for the product, including metadata, promotion settings, and more through Product Settings. 
 

--- a/_docs/products/create-product.md
+++ b/_docs/products/create-product.md
@@ -5,7 +5,8 @@ group: products
 toc: true
 ---
 
-
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 A product in Codefresh is a logical grouping of related Argo CD applications that provides context, versioning, and lifecycle management across environments. Unlike standalone applications in Argo CD, products establish relationships between applications, making it easier to track deployments, manage promotions, and maintain consistency. See [About Products]({{site.baseurl}}/docs/products/about-products/).
 

--- a/_docs/products/promotion-concurrency.md
+++ b/_docs/products/promotion-concurrency.md
@@ -5,6 +5,9 @@ group: products
 toc: true
 ---
 
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
+
 ## Promotion concurrency for products
 
 When multiple promotions are triggered for a product, multiple releases can occur at the same time or concurrently.  

--- a/_docs/products/promotion-flow-triggers.md
+++ b/_docs/products/promotion-flow-triggers.md
@@ -5,6 +5,9 @@ group: products
 toc: true
 ---
 
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
+
 ## Promotion Flows for products
 A Promotion Flow in Codefresh GitOps defines the steps, validations, and conditions required to promote a product and its applications from one environment to another.  
 

--- a/_docs/products/promotion-version-properties.md
+++ b/_docs/products/promotion-version-properties.md
@@ -5,6 +5,8 @@ group: products
 toc: true
 ---
 
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Application version and promotable properties for products
 By default, when you promote a product across environments, all its applications and their properties are promoted. Not all properties change with every update, and different environments have different requirements. For example, while development environments may allow frequent updates, staging and production environments often require stricter controls.

--- a/_docs/products/releases-in-products.md
+++ b/_docs/products/releases-in-products.md
@@ -5,6 +5,9 @@ group: products
 toc: true
 ---
 
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
+
 ## Product Releases
 The **Releases** feature provides visibility into a product’s deployment lifecycle as it moves through different environments during promotions.
 

--- a/_docs/promotions/create-promotion-sequence.md
+++ b/_docs/promotions/create-promotion-sequence.md
@@ -5,9 +5,8 @@ group: promotions
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Promotion setup guidelines
 This article outlines the tasks required to configure, trigger, and monitor promotions in Codefresh GitOps.

--- a/_docs/promotions/getting-started.md
+++ b/_docs/promotions/getting-started.md
@@ -5,9 +5,8 @@ group: promotions
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 Use the links below to dive into the basics of promotions in Codefresh GitOps, explore key components, and configure your first promotion flow.
 

--- a/_docs/promotions/product-promotion-props.md
+++ b/_docs/promotions/product-promotion-props.md
@@ -8,9 +8,8 @@ redirect-from:
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Promotion Settings for products
 

--- a/_docs/promotions/product-releases.md
+++ b/_docs/promotions/product-releases.md
@@ -5,9 +5,8 @@ group: promotions
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Releases for promotions in GitOps
 Releases in Codefresh GitOps offer a consolidated view of the deployment lifecycle for a product as it progresses through environments during a promotion. They enable you to track, visualize, and analyze changes from the initial trigger to the final deployment, providing comprehensive insights for all stakeholders.

--- a/_docs/promotions/promotion-components.md
+++ b/_docs/promotions/promotion-components.md
@@ -5,9 +5,8 @@ group: promotions
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Promotion components
 If you are new to promotions in GitOps, understanding the key entities involved in the promotion process helps clarify their roles.

--- a/_docs/promotions/promotion-context-promotion-workflows.md
+++ b/_docs/promotions/promotion-context-promotion-workflows.md
@@ -5,9 +5,8 @@ group: promotions
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## About promotion contexts
 

--- a/_docs/promotions/promotion-flow.md
+++ b/_docs/promotions/promotion-flow.md
@@ -8,9 +8,8 @@ redirect-from:
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Promotion Flows in Codefresh GitOps
 A Promotion Flow is a sequence of automated actions that systematically move code changes through environments, from development to production. This structured approach enhances deployment reliability and efficiency, ensuring changes meet quality standards before reaching end users.

--- a/_docs/promotions/promotion-hooks.md
+++ b/_docs/promotions/promotion-hooks.md
@@ -5,9 +5,8 @@ group: promotions"
 toc: true
 ---
 
->**Promotions is currently in development.**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Promotion hooks overview
 

--- a/_docs/promotions/promotion-limitations.md
+++ b/_docs/promotions/promotion-limitations.md
@@ -5,9 +5,8 @@ group: promotions
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Current limitations for promotions
 The table below lists the current limitations when working with promotions.

--- a/_docs/promotions/promotion-policy.md
+++ b/_docs/promotions/promotion-policy.md
@@ -8,9 +8,8 @@ redirect-from:
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Promotions with Promotion Policies
 When a promotion is triggered for a product in an environment, it's essential to govern promotion behavior for that environment, both before and after promoting changes.  

--- a/_docs/promotions/promotion-workflow.md
+++ b/_docs/promotions/promotion-workflow.md
@@ -8,9 +8,8 @@ group: promotions
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Promotion Workflows in Codefresh GitOps
 

--- a/_docs/promotions/promotions-overview.md
+++ b/_docs/promotions/promotions-overview.md
@@ -5,10 +5,8 @@ group: promotions
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
-
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Promotions with GitOps: The Codefresh advantage
 Continuous Delivery (CD) is an essential practice in the software development lifecycle (SDLC) that automates the release process, ensuring consistent and reliable deployment of application updates across environments. CD bridges the gap between development and operations, empowering teams to deliver changes to production with speed and confidence.

--- a/_docs/promotions/service-accounts-promotion-workflows.md
+++ b/_docs/promotions/service-accounts-promotion-workflows.md
@@ -5,9 +5,8 @@ group: promotions
 toc: true
 ---
 
->**Promotions is currently in development.**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 ## Service accounts & service account roles for Promotion Workflows
 Service accounts are essential for all types of Promotion Workflows in GitOps Cloud. These accounts provide the necessary permissions for workflows to interact with clusters and other resources during the promotion process, including when hooks are used. 

--- a/_docs/promotions/trigger-promotions.md
+++ b/_docs/promotions/trigger-promotions.md
@@ -5,9 +5,8 @@ group: promotions
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 Promotions are a key part of the continuous delivery (CD) process, controlling how software moves through various environments based on automated triggers or manual inputs. 
 

--- a/_docs/promotions/yaml.md
+++ b/_docs/promotions/yaml.md
@@ -8,6 +8,9 @@ redirect-from:
 toc: true
 ---
 
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
+
 Codefresh provides two options for defining manifests for promotion entities: Form mode and YAML mode.
 
 If you prefer working with YAML, create manifests for promotion entities using our YAML examples:  

--- a/_docs/promotions/yaml/product-crd.md
+++ b/_docs/promotions/yaml/product-crd.md
@@ -8,6 +8,8 @@ redirect-from:
 toc: true
 ---
 
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 Codefresh provides two options for defining manifests for promotion entities: Form mode and YAML mode.
 

--- a/_docs/promotions/yaml/promotion-flow-crd.md
+++ b/_docs/promotions/yaml/promotion-flow-crd.md
@@ -8,9 +8,8 @@ redirect-from:
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 Codefresh provides two options for defining manifests for promotion entities: [Chart mode]({{site.baseurl}}/docs/promotions/promotion-flow/) and YAML mode.
 

--- a/_docs/promotions/yaml/promotion-policy-crd.md
+++ b/_docs/promotions/yaml/promotion-policy-crd.md
@@ -8,9 +8,8 @@ redirect-from:
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 Codefresh provides two options for defining manifests for promotion entities: Form mode and YAML mode.
 

--- a/_docs/promotions/yaml/promotion-template-crd.md
+++ b/_docs/promotions/yaml/promotion-template-crd.md
@@ -8,9 +8,8 @@ redirect-from:
 toc: true
 ---
 
->**Promotions is currently in development**  
-This feature is still under active development and we've identified some issues with its resilience and reliability, particularly with recovery from cluster and network problems. We are currently upgrading our architecture to resolve these known issues and add self-healing capabilities.
-We don't recommend using Promotions for mission-critical or production deployments at this time.
+>**Promotions has been disabled**  
+Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.
 
 Codefresh provides two options for defining manifests for promotion entities: Form mode and YAML mode.
 


### PR DESCRIPTION
## What
Adds a **"Promotions has been disabled"** note to every page related to promotion across environments, stating the feature is turned off and will no longer be available in GitOps Runtimes released after **version 0.24.0**.

Note text used site-wide:
> **Promotions has been disabled**
> Promotions has been disabled and turned off, and will no longer be available in GitOps Runtimes released after version 0.24.0.

## Scope
- **Promotions** section — all pages (replaces the old "currently in development" note)
- **Products** section — all pages
- **Environments** section + **GitOps Products/Environments dashboards**
- **GitOps quick starts** — stripped the promotion sections from the hub; flagged the standalone promotion quick starts with the note

Branched off `master` so the diff is isolated from the parallel `/gitops` redirect removal work (PR #1436). Only `_docs/` content pages are touched (no `nav.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)